### PR TITLE
Bugfix: Updates coming in reverse order

### DIFF
--- a/src/BufferUpdate.re
+++ b/src/BufferUpdate.re
@@ -6,6 +6,19 @@ type t = {
   version: int,
 };
 
+let show = (v: t) => {
+  Printf.sprintf(
+    "id: %d startLine: %d endLine: %d version: %d lines:\n",
+    v.id,
+    v.startLine,
+    v.endLine,
+    v.version,
+  )
+  ++ "----"
+  ++ Array.fold_left((s, prev) => prev ++ s ++ "\n", "", v.lines)
+  ++ "----";
+};
+
 let getAllLines = (buffer: Native.buffer) => {
   let startLine = 1;
   let endLine = Native.vimBufferGetLineCount(buffer) + 1;

--- a/src/Vim.re
+++ b/src/Vim.re
@@ -21,7 +21,8 @@ let queuedFunctions: ref(list(fn)) = ref([]);
 let queue = f => queuedFunctions := [f, ...queuedFunctions^];
 
 let flushQueue = () => {
-  List.iter(f => f(), queuedFunctions^);
+  queuedFunctions^ |> List.rev |> List.iter(f => f());
+
   queuedFunctions := [];
 };
 

--- a/test/BufferUpdatesTest.re
+++ b/test/BufferUpdatesTest.re
@@ -90,6 +90,37 @@ describe("Buffer.onUpdate", ({describe, _}) => {
 
       dispose();
     });
+    test("join", ({expect}) => {
+      let _ = resetBuffer();
+
+      let updates: ref(list(BufferUpdate.t)) = ref([]);
+      let dispose =
+        Buffer.onUpdate(upd => {
+          print_endline(BufferUpdate.show(upd));
+          updates := [upd, ...updates^];
+        });
+
+      input("J");
+      expect.int(List.length(updates^)).toBe(2);
+
+      /* Fix up ordering of calls - the order of the list gets inverted
+            because we put the latest element in front
+         */
+      updates := List.rev(updates^);
+
+      /* First update - actually modifies the line */
+      let firstUpdate = List.nth(updates^, 0);
+      /* Second update - deletes the extra line */
+      let secondUpdate = List.nth(updates^, 1);
+
+      /* Verify updates came in correct order */
+      expect.bool(firstUpdate.version < secondUpdate.version).toBe(true);
+
+      expect.int(Array.length(firstUpdate.lines)).toBe(1);
+      expect.int(Array.length(secondUpdate.lines)).toBe(0);
+
+      dispose();
+    });
   });
   describe("insert mode", ({test, _}) =>
     test("single file", ({expect}) => {


### PR DESCRIPTION
__Issue:__ Several commands in Onivim 2 would not render as expected.

For example, running the `J` command, or any case where lines were merged and then deleted, would cause it to appear the text disappeared (the line wouldn't get merged).

__Defect:__ The buffer updates were sent in reverse order - the latest ones first. The problem with this is that buffer updates are versioned, and if buffer update 22 is processed, earlier buffer updates will be ignored. In the case of a `J` join operation - the first buffer update modifies the merged line, and the second buffer update deletes the line. We're losing the first buffer update due to this ordering.

__Fix:__ Dispatch the buffer updates (and all the queued updates) in the correct order