### PR TITLE
Buffer stress tests

### DIFF
--- a/test/StressTest.re
+++ b/test/StressTest.re
@@ -1,0 +1,78 @@
+open TestFramework;
+open Vim;
+
+let resetBuffer = () => Helpers.resetBuffer("test/testfile.txt");
+
+describe("Stress", ({describe, _}) => {
+  describe("Adding lots of lines", ({test, _}) => {
+    test("Adding 1 million lines", ({expect}) => {
+
+      let _ = resetBuffer();
+      let buffer = Buffer.openFile("test/lines_100.txt");
+
+      // Now lets duplicate the buffer a bunch.
+      input("yG");
+      input("9999p");
+
+      expect.int(Buffer.getLineCount(buffer)).toBe(1000000);
+    });
+
+    test("Repeat adding 1 million lines", ({expect}) => {
+
+      let _ = resetBuffer();
+      let buffer = Buffer.openFile("test/lines_100.txt");
+
+      // Now lets duplicate the buffer a bunch.
+      input("yG");
+      input("9999p");
+
+      expect.int(Buffer.getLineCount(buffer)).toBe(1000000);
+    });
+
+    // test("Undoing 1 million lines", ({expect}) => {
+
+    //   let _ = resetBuffer();
+    //   let buffer = Buffer.openFile("test/lines_100.txt")
+
+    //   // Now lets duplicate the buffer a bunch.
+    //   input("yG");
+    //   input("9999p");
+
+    //   expect.int(Buffer.getLineCount(buffer)).toBe(1000000);
+
+    //   // Okay, now lets issue an undo and make sure we don't crash.
+    //   input("u");
+
+    //   expect.int(Buffer.getLineCount(buffer)).toBe(100);
+    // });
+
+    // test("Adding 10 million lines", ({expect}) => {
+
+    //   let _ = resetBuffer();
+    //   let buffer = Buffer.openFile("test/lines_100.txt");
+
+    //   // Now lets duplicate the buffer a bunch.
+    //   input("yG");
+    //   input("99999p");
+
+    //   expect.int(Buffer.getLineCount(buffer)).toBe(10000000);
+    // });
+
+    // test("Undoing 10 million lines", ({expect}) => {
+
+    //   let _ = resetBuffer();
+    //   let buffer = Buffer.openFile("test/lines_100.txt")
+
+    //   // Now lets duplicate the buffer a bunch.
+    //   input("yG");
+    //   input("99999p");
+
+    //   expect.int(Buffer.getLineCount(buffer)).toBe(10000000);
+
+    //   // Okay, now lets issue an undo and make sure we don't crash.
+    //   input("u");
+
+    //   expect.int(Buffer.getLineCount(buffer)).toBe(100);
+    // });
+  });
+});


### PR DESCRIPTION
Starting to add some buffer stress tests, to narrow down what is happening in https://github.com/onivim/oni2/issues/296.

What is odd currently is that locally the second test fails, despite being a copy-paste of the first test. As far as I can see, I'm resetting correctly, at least based on the buffer test I'm basing this off.