### PR TITLE
Bugfix: Completion crash on no completions available

### DIFF
--- a/src/bindings.c
+++ b/src/bindings.c
@@ -377,18 +377,22 @@ CAMLprim value libvim_vimCommandLineGetCompletions(value unit) {
   CAMLparam0();
   CAMLlocal1(ret);
 
-  char **completions;
-  int count;
+  char_u **completions = NULL;
+  int count = 0;
 
   vimCommandLineGetCompletions(&completions, &count);
 
-  ret = caml_alloc(count, 0);
-  for (int i = 0; i < count; i++) {
-    Store_field(ret, i, caml_copy_string(completions[i]));
-  }
+  if (count == 0) {
+    ret = Atom(0);
+  } else {
+    ret = caml_alloc(count, 0);
+    for (int i = 0; i < count; i++) {
+      Store_field(ret, i, caml_copy_string(completions[i]));
+    }
 
-  if (completions != NULL) {
-    vim_free(completions);
+    if (completions != NULL) {
+      vim_free(completions);
+    }
   }
 
   CAMLreturn(ret);

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -389,10 +389,10 @@ CAMLprim value libvim_vimCommandLineGetCompletions(value unit) {
     for (int i = 0; i < count; i++) {
       Store_field(ret, i, caml_copy_string(completions[i]));
     }
-
-    if (completions != NULL) {
-      vim_free(completions);
-    }
+  }
+  
+  if (completions != NULL) {
+    vim_free(completions);
   }
 
   CAMLreturn(ret);

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -388,11 +388,10 @@ CAMLprim value libvim_vimCommandLineGetCompletions(value unit) {
     ret = caml_alloc(count, 0);
     for (int i = 0; i < count; i++) {
       Store_field(ret, i, caml_copy_string(completions[i]));
+      vim_free(completions[i]);
     }
-  }
-  
-  if (completions != NULL) {
-    vim_free(completions);
+    
+     vim_free(completions);
   }
 
   CAMLreturn(ret);

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -390,8 +390,8 @@ CAMLprim value libvim_vimCommandLineGetCompletions(value unit) {
       Store_field(ret, i, caml_copy_string(completions[i]));
       vim_free(completions[i]);
     }
-    
-     vim_free(completions);
+
+    vim_free(completions);
   }
 
   CAMLreturn(ret);

--- a/test/CommandLineTest.re
+++ b/test/CommandLineTest.re
@@ -21,6 +21,25 @@ describe("CommandLine", ({describe, _}) => {
     })
   );
 
+  describe("getCompletions", ({test, _}) => {
+    test("basic completion test", ({expect}) => {
+      let _ = reset();
+      input(":");
+      input("e");
+
+      expect.int(Array.length(CommandLine.getCompletions())).toBe(20);
+    });
+    
+    test("regression test - eh", ({expect}) => {
+      let _ = reset();
+      input(":");
+      input("e");
+      input("h");
+
+      expect.int(Array.length(CommandLine.getCompletions())).toBe(0);
+    });
+  });
+
   describe("listeners", ({test, _}) => {
     test("enter / leave listeners", ({expect}) => {
       open Vim.Types;

--- a/test/CommandLineTest.re
+++ b/test/CommandLineTest.re
@@ -29,6 +29,18 @@ describe("CommandLine", ({describe, _}) => {
 
       expect.int(Array.length(CommandLine.getCompletions())).toBe(20);
     });
+    
+    test("request completions multiple times", ({expect}) => {
+      let _ = reset();
+      input(":");
+      input("e");
+
+      expect.int(Array.length(CommandLine.getCompletions())).toBe(20);
+      expect.int(Array.length(CommandLine.getCompletions())).toBe(20);
+
+      let completions = CommandLine.getCompletions();
+      expect.string(completions[0]).toEqual("earlier");
+    });
 
     test("regression test - eh", ({expect}) => {
       let _ = reset();

--- a/test/CommandLineTest.re
+++ b/test/CommandLineTest.re
@@ -29,7 +29,7 @@ describe("CommandLine", ({describe, _}) => {
 
       expect.int(Array.length(CommandLine.getCompletions())).toBe(20);
     });
-    
+
     test("regression test - eh", ({expect}) => {
       let _ = reset();
       input(":");

--- a/test/CommandLineTest.re
+++ b/test/CommandLineTest.re
@@ -29,7 +29,7 @@ describe("CommandLine", ({describe, _}) => {
 
       expect.int(Array.length(CommandLine.getCompletions())).toBe(20);
     });
-    
+
     test("request completions multiple times", ({expect}) => {
       let _ = reset();
       input(":");


### PR DESCRIPTION
__Issue:__ Typing a command with no completions, like `:eh`, will cause a crash like: 

```
[INFO] VimStoreConnector::checkCommandLineCompletions
Oni2(4753,0x111f695c0) malloc: *** error for object 0x107712578: pointer being freed was not allocated
Oni2(4753,0x111f695c0) malloc: *** set a breakpoint in malloc_error_break to debug
```

__Fix:__ In the case of 0 completions, just return `Atom` instead of `alloc`'ing, and make sure `completions` is initialized to `NULL`.