### PR TITLE
Feature: Add 'onFilenameChanged' event for sav command

### DIFF
--- a/src/Buffer.re
+++ b/src/Buffer.re
@@ -51,3 +51,7 @@ let onEnter = (f: Listeners.bufferListener) => {
 let onUpdate = (f: Listeners.bufferUpdateListener) => {
   Event.add(f, Listeners.bufferUpdate);
 };
+
+let onFilenameChanged = (f: Listeners.bufferFilenameChangedListener) => {
+  Event.add(f, Listeners.bufferFilenameChanged);
+};

--- a/src/Buffer.rei
+++ b/src/Buffer.rei
@@ -70,3 +70,11 @@ let onEnter: Listeners.bufferListener => Event.unsubscribe;
 Returns a function that can be called to unsubscribe.
 */
 let onUpdate: Listeners.bufferUpdateListener => Event.unsubscribe;
+
+/**
+[onFileNameChanged(f)] adds a listener [f] that is called whenever the filename
+associated with a buffer changes. This could happen via a `:sav` command.
+
+Returns a function that can be called to unsubscribe.
+*/
+let onFilenameChanged: Listeners.bufferFilenameChangedListener => Event.unsubscribe;

--- a/src/Buffer.rei
+++ b/src/Buffer.rei
@@ -77,4 +77,5 @@ associated with a buffer changes. This could happen via a `:sav` command.
 
 Returns a function that can be called to unsubscribe.
 */
-let onFilenameChanged: Listeners.bufferFilenameChangedListener => Event.unsubscribe;
+let onFilenameChanged:
+  Listeners.bufferFilenameChangedListener => Event.unsubscribe;

--- a/src/BufferInternal.re
+++ b/src/BufferInternal.re
@@ -25,10 +25,11 @@ let notifyUpdate = (buffer: t) => {
     );
 };
 
-let string_opt = s => switch(s) {
-| None => ""
-| Some(v) => v
-};
+let string_opt = s =>
+  switch (s) {
+  | None => ""
+  | Some(v) => v
+  };
 
 let doFullUpdate = (buffer: t) => {
   let bu = BufferUpdate.createFull(buffer);
@@ -67,8 +68,11 @@ let checkCurrentBufferForUpdate = () => {
 
         if (!String.equal(string_opt(lastF), string_opt(newFileName))) {
           lastFilename := newFileName;
-          Event.dispatch(BufferMetadata.ofBuffer(buffer), Listeners.bufferFilenameChanged);
-        }
+          Event.dispatch(
+            BufferMetadata.ofBuffer(buffer),
+            Listeners.bufferFilenameChanged,
+          );
+        };
       }
     | None =>
       Event.dispatch(buffer, Listeners.bufferEnter);

--- a/src/Listeners.re
+++ b/src/Listeners.re
@@ -2,7 +2,7 @@ open Types;
 
 type autocmdListener = (autocmd, Native.buffer) => unit;
 type bufferListener = Native.buffer => unit;
-type bufferFilenameChangedListener = (BufferMetadata.t) =>  unit;
+type bufferFilenameChangedListener = BufferMetadata.t => unit;
 type bufferUpdateListener = BufferUpdate.t => unit;
 type commandLineUpdateListener = Types.cmdline => unit;
 type directoryChangedListener = string => unit;
@@ -19,7 +19,8 @@ type noopListener = unit => unit;
 
 let autocmd: ref(list(autocmdListener)) = ref([]);
 let bufferEnter: ref(list(bufferListener)) = ref([]);
-let bufferFilenameChanged: ref(list(bufferFilenameChangedListener)) = ref([]);
+let bufferFilenameChanged: ref(list(bufferFilenameChangedListener)) =
+  ref([]);
 let bufferUpdate: ref(list(bufferUpdateListener)) = ref([]);
 let bufferLeave: ref(list(bufferListener)) = ref([]);
 let commandLineEnter: ref(list(commandLineUpdateListener)) = ref([]);

--- a/src/Listeners.re
+++ b/src/Listeners.re
@@ -2,6 +2,7 @@ open Types;
 
 type autocmdListener = (autocmd, Native.buffer) => unit;
 type bufferListener = Native.buffer => unit;
+type bufferFilenameChangedListener = (BufferMetadata.t) =>  unit;
 type bufferUpdateListener = BufferUpdate.t => unit;
 type commandLineUpdateListener = Types.cmdline => unit;
 type directoryChangedListener = string => unit;
@@ -18,6 +19,7 @@ type noopListener = unit => unit;
 
 let autocmd: ref(list(autocmdListener)) = ref([]);
 let bufferEnter: ref(list(bufferListener)) = ref([]);
+let bufferFilenameChanged: ref(list(bufferFilenameChangedListener)) = ref([]);
 let bufferUpdate: ref(list(bufferUpdateListener)) = ref([]);
 let bufferLeave: ref(list(bufferListener)) = ref([]);
 let commandLineEnter: ref(list(commandLineUpdateListener)) = ref([]);

--- a/test/BufferTest.re
+++ b/test/BufferTest.re
@@ -21,12 +21,14 @@ describe("Buffer", ({describe, _}) => {
   );
   describe("onFilenameChanged", ({test, _}) => {
     test(
-      "switching to a new file should not trigger an onFilenameChanged event", ({expect}) => {
+      "switching to a new file should not trigger an onFilenameChanged event",
+      ({expect}) => {
       let _ = resetBuffer();
 
       let updates = ref([]);
       let onEnter = ref([]);
-      let dispose = Buffer.onFilenameChanged(meta => updates := [meta, ...updates^]);
+      let dispose =
+        Buffer.onFilenameChanged(meta => updates := [meta, ...updates^]);
       let dispose2 = Buffer.onEnter(v => onEnter := [v, ...onEnter^]);
 
       command("e! some-new-file.txt");
@@ -40,27 +42,32 @@ describe("Buffer", ({describe, _}) => {
       dispose2();
     });
     test(
-      "saving to a new file should trigger an onFilenameChanged event", ({expect}) => {
+      "saving to a new file should trigger an onFilenameChanged event",
+      ({expect}) => {
       let _ = resetBuffer();
 
       let updates = ref([]);
       let onEnter = ref([]);
-      let dispose = Buffer.onFilenameChanged(meta => updates := [meta, ...updates^]);
+      let dispose =
+        Buffer.onFilenameChanged(meta => updates := [meta, ...updates^]);
       let dispose2 = Buffer.onEnter(v => onEnter := [v, ...onEnter^]);
 
-      let string_opt = s => switch(s) {
-      | None => ""
-      | Some(v) => v
-      };
+      let string_opt = s =>
+        switch (s) {
+        | None => ""
+        | Some(v) => v
+        };
 
-      let previousFilename = Buffer.getCurrent() |> Buffer.getFilename |> string_opt;
+      let previousFilename =
+        Buffer.getCurrent() |> Buffer.getFilename |> string_opt;
       command("sav! some-new-file-2.txt");
-      let newFilename = Buffer.getCurrent() |> Buffer.getFilename |> string_opt;
+      let newFilename =
+        Buffer.getCurrent() |> Buffer.getFilename |> string_opt;
 
       expect.bool(String.equal(previousFilename, newFilename)).toBe(false);
 
       expect.int(List.length(updates^)).toBe(1);
-      
+
       /* A buffer enter event should not have been triggered */
       expect.int(List.length(onEnter^)).toBe(0);
 

--- a/test/BufferTest.re
+++ b/test/BufferTest.re
@@ -21,6 +21,32 @@ describe("Buffer", ({describe, _}) => {
   );
   describe("onEnter", ({test, _}) => {
     test(
+      "saving to a new file should trigger a buffer enter event", ({expect}) => {
+      let _ = resetBuffer();
+
+      let updates: ref(list(Buffer.t)) = ref([]);
+      let dispose = Buffer.onEnter(upd => updates := [upd, ...updates^]);
+
+      let derp = s => switch(s) {
+      | None => ""
+      | Some(v) => v
+      };
+
+      let _ = onMessage((_, s, t) => print_endline ("MESSAGE: " ++ s ++ "|" ++ t));
+
+      let previousFilename = Buffer.getCurrent() |> Buffer.getFilename |> derp;
+      print_endline ("old id: " ++ previousFilename);
+      command("sav some-new-file.txt");
+      let newFileName = Buffer.getCurrent() |> Buffer.getFilename |> derp;
+      print_endline ("new filename: " ++ newFileName);
+
+      /*expect.bool(newMetadata.id == previousMetadata.id).toBe(false);*/
+
+      expect.int(List.length(updates^)).toBe(1);
+
+      dispose();
+    });
+    test(
       "editing a new file should trigger a buffer enter event", ({expect}) => {
       let _ = resetBuffer();
 

--- a/test/BufferTest.re
+++ b/test/BufferTest.re
@@ -19,33 +19,56 @@ describe("Buffer", ({describe, _}) => {
       expect.int(Buffer.getLineCount(buffer)).toBe(3);
     })
   );
-  describe("onEnter", ({test, _}) => {
+  describe("onFilenameChanged", ({test, _}) => {
     test(
-      "saving to a new file should trigger a buffer enter event", ({expect}) => {
+      "switching to a new file should not trigger an onFilenameChanged event", ({expect}) => {
       let _ = resetBuffer();
 
-      let updates: ref(list(Buffer.t)) = ref([]);
-      let dispose = Buffer.onEnter(upd => updates := [upd, ...updates^]);
+      let updates = ref([]);
+      let onEnter = ref([]);
+      let dispose = Buffer.onFilenameChanged(meta => updates := [meta, ...updates^]);
+      let dispose2 = Buffer.onEnter(v => onEnter := [v, ...onEnter^]);
 
-      let derp = s => switch(s) {
+      command("e! some-new-file.txt");
+
+      /* A filename changed event should not have been triggered */
+      expect.int(List.length(updates^)).toBe(0);
+      /* An enter event should've been triggered */
+      expect.int(List.length(onEnter^)).toBe(1);
+
+      dispose();
+      dispose2();
+    });
+    test(
+      "saving to a new file should trigger an onFilenameChanged event", ({expect}) => {
+      let _ = resetBuffer();
+
+      let updates = ref([]);
+      let onEnter = ref([]);
+      let dispose = Buffer.onFilenameChanged(meta => updates := [meta, ...updates^]);
+      let dispose2 = Buffer.onEnter(v => onEnter := [v, ...onEnter^]);
+
+      let string_opt = s => switch(s) {
       | None => ""
       | Some(v) => v
       };
 
-      let _ = onMessage((_, s, t) => print_endline ("MESSAGE: " ++ s ++ "|" ++ t));
+      let previousFilename = Buffer.getCurrent() |> Buffer.getFilename |> string_opt;
+      command("sav! some-new-file-2.txt");
+      let newFilename = Buffer.getCurrent() |> Buffer.getFilename |> string_opt;
 
-      let previousFilename = Buffer.getCurrent() |> Buffer.getFilename |> derp;
-      print_endline ("old id: " ++ previousFilename);
-      command("sav some-new-file.txt");
-      let newFileName = Buffer.getCurrent() |> Buffer.getFilename |> derp;
-      print_endline ("new filename: " ++ newFileName);
-
-      /*expect.bool(newMetadata.id == previousMetadata.id).toBe(false);*/
+      expect.bool(String.equal(previousFilename, newFilename)).toBe(false);
 
       expect.int(List.length(updates^)).toBe(1);
+      
+      /* A buffer enter event should not have been triggered */
+      expect.int(List.length(onEnter^)).toBe(0);
 
       dispose();
+      dispose2();
     });
+  });
+  describe("onEnter", ({test, _}) => {
     test(
       "editing a new file should trigger a buffer enter event", ({expect}) => {
       let _ = resetBuffer();


### PR DESCRIPTION
__Issue:__ The `:sav` command isn't working correctly - the buffer isn't being updated to point to the new file.

__Defect:__ We don't check if the buffer metadata has been updated for input / commands.

__Fix:__ Check buffer metadata and dispatch appropriate event