### PR TITLE
Bugfix: Linux hangs on :vsp

### DIFF
--- a/src/bindings.c
+++ b/src/bindings.c
@@ -117,9 +117,7 @@ void onWindowMovement(windowMovement_T movementType, int count) {
     lv_onWindowMovement = caml_named_value("lv_onWindowMovement");
   }
 
-  caml_acquire_runtime_system();
   caml_callback2(*lv_onWindowMovement, Val_int(movementType), Val_int(count));
-  caml_release_runtime_system();
   CAMLreturn0;
 }
 
@@ -133,10 +131,8 @@ void onWindowSplit(windowSplit_T splitType, char_u *path) {
     lv_onWindowSplit = caml_named_value("lv_onWindowSplit");
   }
 
-  caml_acquire_runtime_system();
   pathString = caml_copy_string(path);
   caml_callback2(*lv_onWindowSplit, Val_int(splitType), pathString);
-  caml_release_runtime_system();
   CAMLreturn0;
 }
 


### PR DESCRIPTION
__Issue:__ This was a similar issue to #49 , which was causing hangs / crashes during command line completion on OS X.  Running the `:vsp` command causes a hang on pressing enter on arch linux.

__Defect:__ We are inappropriately releasing the OCaml runtime, which causes a crash when the garbage collector kicks in.

__Fix:__ Remove remaining acquire / release runtime references