### PR TITLE
Bugfix: Send buffer update after enter / metadata changed

### DIFF
--- a/src/BufferInternal.re
+++ b/src/BufferInternal.re
@@ -48,11 +48,6 @@ let checkCurrentBufferForUpdate = () => {
     Event.dispatch(buffer, Listeners.bufferEnter);
     Event.dispatch(update, Listeners.bufferUpdate);
   | Some(lastVersion) =>
-    let newVersion = Native.vimBufferGetChangedTick(buffer);
-
-    if (newVersion > lastVersion) {
-      doFullUpdate(buffer);
-    };
 
     /* Check if the current buffer changed */
     switch (currentBuffer^) {
@@ -77,6 +72,11 @@ let checkCurrentBufferForUpdate = () => {
     | None =>
       Event.dispatch(buffer, Listeners.bufferEnter);
       currentBuffer := Some(buffer);
+    };
+    let newVersion = Native.vimBufferGetChangedTick(buffer);
+
+    if (newVersion > lastVersion) {
+      doFullUpdate(buffer);
     };
   };
 };

--- a/src/BufferInternal.re
+++ b/src/BufferInternal.re
@@ -48,7 +48,6 @@ let checkCurrentBufferForUpdate = () => {
     Event.dispatch(buffer, Listeners.bufferEnter);
     Event.dispatch(update, Listeners.bufferUpdate);
   | Some(lastVersion) =>
-
     /* Check if the current buffer changed */
     switch (currentBuffer^) {
     | Some(v) =>


### PR DESCRIPTION
This fixes a timing issue with the way we send buffer events. Previously, we'd send buffer updates _before_ buffer enter / metadata changed events. This changes our flow to send buffer updates _after_ these events.