### PR TITLE
API: Vim.Search.onStopSearchHighlight

### DIFF
--- a/src/Listeners.re
+++ b/src/Listeners.re
@@ -32,6 +32,7 @@ let leftColumnChanged: ref(list(leftColumnChangedListener)) = ref([]);
 let message: ref(list(messageListener)) = ref([]);
 let modeChanged: ref(list(modeChangedListener)) = ref([]);
 let quit: ref(list(quitListener)) = ref([]);
+let stopSearchHighlight: ref(list(noopListener)) = ref([]);
 let topLineChanged: ref(list(topLineChangedListener)) = ref([]);
 let visualRangeChanged: ref(list(visualRangeChangedListener)) = ref([]);
 let windowMovement: ref(list(windowMovementListener)) = ref([]);

--- a/src/Search.re
+++ b/src/Search.re
@@ -21,3 +21,5 @@ let getMatchingPair = () => {
   | Some((line, column)) => Some(Position.create(~line, ~column))
   };
 };
+
+let onStopSearchHighlight = f => Event.add(f, Listeners.stopSearchHighlight);

--- a/src/Vim.re
+++ b/src/Vim.re
@@ -122,12 +122,17 @@ let _onWindowSplit = (st, p) => {
   queue(() => Event.dispatch2(st, p, Listeners.windowSplit));
 };
 
+let _onStopSearch = () => {
+  queue(() => Event.dispatch((), Listeners.stopSearchHighlight);
+};
+
 let init = () => {
   Callback.register("lv_onBufferChanged", _onBufferChanged);
   Callback.register("lv_onAutocommand", _onAutocommand);
   Callback.register("lv_onDirectoryChanged", _onDirectoryChanged);
   Callback.register("lv_onMessage", _onMessage);
   Callback.register("lv_onQuit", _onQuit);
+  Callback.register("lv_onStopSearch", _onStopSearch);
   Callback.register("lv_onWindowMovement", _onWindowMovement);
   Callback.register("lv_onWindowSplit", _onWindowSplit);
 

--- a/src/Vim.re
+++ b/src/Vim.re
@@ -123,7 +123,7 @@ let _onWindowSplit = (st, p) => {
 };
 
 let _onStopSearch = () => {
-  queue(() => Event.dispatch((), Listeners.stopSearchHighlight);
+  queue(() => Event.dispatch((), Listeners.stopSearchHighlight));
 };
 
 let init = () => {

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -108,6 +108,19 @@ void onQuit(buf_T *buf, int isForced) {
   CAMLreturn0;
 }
 
+void onStopSearch(void) {
+  CAMLparam0();
+
+  static value *lv_onStopSearch = NULL;
+
+  if (lv_onStopSearch == NULL) {
+    lv_onStopSearch = caml_named_value("lv_onStopSearch");
+  }
+
+  caml_callback(*lv_onStopSearch, Val_unit);
+  CAMLreturn0;
+}
+
 void onWindowMovement(windowMovement_T movementType, int count) {
   CAMLparam0();
 
@@ -166,6 +179,7 @@ CAMLprim value libvim_vimInit(value unit) {
   vimSetDirectoryChangedCallback(&onDirectoryChanged);
   vimSetMessageCallback(&onMessage);
   vimSetQuitCallback(&onQuit);
+  vimSetStopSearchCallback(&onStopSearch);
   vimSetWindowMovementCallback(&onWindowMovement);
   vimSetWindowSplitCallback(&onWindowSplit);
 

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -179,7 +179,7 @@ CAMLprim value libvim_vimInit(value unit) {
   vimSetDirectoryChangedCallback(&onDirectoryChanged);
   vimSetMessageCallback(&onMessage);
   vimSetQuitCallback(&onQuit);
-  vimSetStopSearchCallback(&onStopSearch);
+  vimSetStopSearchHighlightCallback(&onStopSearch);
   vimSetWindowMovementCallback(&onWindowMovement);
   vimSetWindowSplitCallback(&onWindowSplit);
 

--- a/test/SearchTest.re
+++ b/test/SearchTest.re
@@ -41,23 +41,24 @@ describe("Search", ({describe, _}) => {
       expect.int(Array.length(highlights)).toBe(1);
     });
   });
-  
-  describe("onStopSearchHighlight", ({test, _}) => {
-    test("onStopSearchHighlight dispatches when nohlsearch is called", ({expect}) => {
+
+  describe("onStopSearchHighlight", ({test, _}) =>
+    test(
+      "onStopSearchHighlight dispatches when nohlsearch is called",
+      ({expect}) => {
       let _ = reset();
 
       let callCount = ref(0);
-      let unsubscribe = Vim.Search.onStopSearchHighlight(() => {
-        incr(callCount);
-      });
+      let unsubscribe =
+        Vim.Search.onStopSearchHighlight(() => incr(callCount));
 
       Vim.command("nohlsearch");
 
       expect.int(callCount^).toBe(1);
 
       unsubscribe();
-    });
-  });
+    })
+  );
 
   describe("getMatchingPair", ({test, _}) => {
     test("get matching bracket for initial character", ({expect}) => {

--- a/test/SearchTest.re
+++ b/test/SearchTest.re
@@ -41,6 +41,23 @@ describe("Search", ({describe, _}) => {
       expect.int(Array.length(highlights)).toBe(1);
     });
   });
+  
+  describe("onStopSearchHighlight", ({test, _}) => {
+    test("onStopSearchHighlight dispatches when nohlsearch is called", ({expect}) => {
+      let _ = reset();
+
+      let callCount = ref(0);
+      let unsubscribe = Vim.Search.onStopSearchHighlight(() => {
+        incr(callCount);
+      });
+
+      Vim.command("nohlsearch");
+
+      expect.int(callCount^).toBe(1);
+
+      unsubscribe();
+    });
+  });
 
   describe("getMatchingPair", ({test, _}) => {
     test("get matching bracket for initial character", ({expect}) => {


### PR DESCRIPTION
This hooks up the `:nohlsearch` event handler to clear search highlights, so that we can pick it up for https://github.com/onivim/oni2/issues/499