### PR TITLE
API: Add `Clipboard.setProvider`

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,14 +19,15 @@
     "@opam/merlin-extend": "0.3",
     "@opam/ocaml-migrate-parsetree": "1.3.1",
     "@opam/biniou": "1.2.0",
-    "@opam/easy-format": "1.3.1"
+    "@opam/easy-format": "1.3.1",
+    "libvim": "link:../libvim1/src"
   },
   "dependencies": {
     "@opam/dune": "*",
     "@esy-ocaml/reason": "3.4.0",
     "refmterr": "*",
     "ocaml": "4.7.1004",
-    "libvim": "8.10869.19"
+    "libvim": "*"
   },
   "devDependencies": {
     "ocaml": "4.7.1004"

--- a/src/Clipboard.re
+++ b/src/Clipboard.re
@@ -1,6 +1,6 @@
 
-type clipboardProvider = (int) => option(string);
+let _provider: ref(option(Types.clipboardProvider)) = ref(None);
 
-let setProvider = (_provider: clipboardProvider) => {
-    ();
+let setProvider = (provider: Types.clipboardProvider) => {
+    _provider := Some(provider);
 };

--- a/src/Clipboard.re
+++ b/src/Clipboard.re
@@ -1,0 +1,6 @@
+
+type clipboardProvider = (int) => option(string);
+
+let setProvider = (_provider: clipboardProvider) => {
+    ();
+};

--- a/src/Clipboard.re
+++ b/src/Clipboard.re
@@ -1,6 +1,5 @@
-
 let _provider: ref(option(Types.clipboardProvider)) = ref(None);
 
 let setProvider = (provider: Types.clipboardProvider) => {
-    _provider := Some(provider);
+  _provider := Some(provider);
 };

--- a/src/Types.re
+++ b/src/Types.re
@@ -11,6 +11,8 @@ module AutoClosingPair = {
 
 type autoClosingPairs = array(AutoClosingPair.t);
 
+type clipboardProvider = (int) => option(array(string));
+
 type mode =
   | Normal
   | Insert

--- a/src/Types.re
+++ b/src/Types.re
@@ -11,7 +11,7 @@ module AutoClosingPair = {
 
 type autoClosingPairs = array(AutoClosingPair.t);
 
-type clipboardProvider = (int) => option(array(string));
+type clipboardProvider = int => option(array(string));
 
 type mode =
   | Normal

--- a/src/Vim.re
+++ b/src/Vim.re
@@ -162,10 +162,10 @@ let _onStopSearch = () => {
 };
 
 let _clipboardGet = (regname: int) => {
-   switch (Clipboard._provider^) {
-   | None => None
-   | Some(v) => v(regname)
-   }
+  switch (Clipboard._provider^) {
+  | None => None
+  | Some(v) => v(regname)
+  };
 };
 
 let init = () => {

--- a/src/Vim.re
+++ b/src/Vim.re
@@ -3,6 +3,7 @@ module AutoCommands = AutoCommands;
 module Buffer = Buffer;
 module BufferMetadata = BufferMetadata;
 module BufferUpdate = BufferUpdate;
+module Clipboard = Clipboard;
 module CommandLine = CommandLine;
 module Cursor = Cursor;
 module Mode = Mode;

--- a/src/Vim.re
+++ b/src/Vim.re
@@ -127,7 +127,15 @@ let _onStopSearch = () => {
   queue(() => Event.dispatch((), Listeners.stopSearchHighlight));
 };
 
+let _clipboardGet = (regname: int) => {
+   switch (Clipboard._provider^) {
+   | None => None
+   | Some(v) => v(regname)
+   }
+};
+
 let init = () => {
+  Callback.register("lv_clipboardGet", _clipboardGet);
   Callback.register("lv_onBufferChanged", _onBufferChanged);
   Callback.register("lv_onAutocommand", _onAutocommand);
   Callback.register("lv_onDirectoryChanged", _onDirectoryChanged);

--- a/src/Vim.rei
+++ b/src/Vim.rei
@@ -58,6 +58,7 @@ module AutoCommands = AutoCommands;
 module Buffer = Buffer;
 module BufferMetadata = BufferMetadata;
 module BufferUpdate = BufferUpdate;
+module Clipboard = Clipboard;
 module CommandLine = CommandLine;
 module Cursor = Cursor;
 module Mode = Mode;

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -8,6 +8,8 @@
 
 #define Val_none Val_int(0)
 
+value relv_clipboardCallback = Val_unit;
+
 static value Val_some(value v) {
   CAMLparam1(v);
   CAMLlocal1(some);
@@ -149,6 +151,10 @@ void onWindowSplit(windowSplit_T splitType, char_u *path) {
   CAMLreturn0;
 }
 
+int getClipboardCallback(int regname, int num_lines, char_u*** lines) {
+  return FALSE;
+}
+
 CAMLprim value libvim_vimAutoClosingPairsSet(value acp) {
   CAMLparam1(acp);
   CAMLlocal1(val);
@@ -176,6 +182,7 @@ CAMLprim value libvim_vimAutoClosingPairsSet(value acp) {
 CAMLprim value libvim_vimInit(value unit) {
   vimSetBufferUpdateCallback(&onBufferChanged);
   vimSetAutoCommandCallback(&onAutocommand);
+  vimSetClipboardGetCallback(&getClipboardCallback);
   vimSetDirectoryChangedCallback(&onDirectoryChanged);
   vimSetMessageCallback(&onMessage);
   vimSetQuitCallback(&onQuit);

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -149,10 +149,10 @@ void onWindowSplit(windowSplit_T splitType, char_u *path) {
   CAMLreturn0;
 }
 
-int getClipboardCallback(int regname, int* num_lines, char_u*** lines) {
+int getClipboardCallback(int regname, int *num_lines, char_u ***lines) {
   CAMLparam0();
   CAMLlocal1(clipboardArray);
-  
+
   static value *lv_clipboardGet = NULL;
 
   if (lv_clipboardGet == NULL) {
@@ -164,12 +164,23 @@ int getClipboardCallback(int regname, int* num_lines, char_u*** lines) {
   int ret = 0;
   // Some
   if (Is_block(v)) {
-    clipboardArray = Field(v, 0); 
+    clipboardArray = Field(v, 0);
     int len = Wosize_val(clipboardArray);
-    printf("Got %d lines!\n", len);
-    ret = 0; 
+
+    *num_lines = len;
+    char_u **out = malloc(sizeof(char_u *) * len);
+
+    for (int i = 0; i < len; i++) {
+      char *sz = String_val(Field(clipboardArray, i));
+      out[i] = malloc((sizeof(char) * strlen(sz)) + 1);
+      strcpy((char *)out[i], sz);
+    }
+    *lines = out;
+
+    ret = 1;
+    // None
   } else {
-    ret = 0; 
+    ret = 0;
   }
 
   CAMLreturn(ret);

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -149,7 +149,6 @@ void onWindowSplit(windowSplit_T splitType, char_u *path) {
   CAMLreturn0;
 }
 
-<<<<<<< HEAD
 int getClipboardCallback(int regname, int *num_lines, char_u ***lines) {
   CAMLparam0();
   CAMLlocal1(clipboardArray);

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -8,8 +8,6 @@
 
 #define Val_none Val_int(0)
 
-value relv_clipboardCallback = Val_unit;
-
 static value Val_some(value v) {
   CAMLparam1(v);
   CAMLlocal1(some);
@@ -151,8 +149,30 @@ void onWindowSplit(windowSplit_T splitType, char_u *path) {
   CAMLreturn0;
 }
 
-int getClipboardCallback(int regname, int num_lines, char_u*** lines) {
-  return FALSE;
+int getClipboardCallback(int regname, int* num_lines, char_u*** lines) {
+  CAMLparam0();
+  CAMLlocal1(clipboardArray);
+  
+  static value *lv_clipboardGet = NULL;
+
+  if (lv_clipboardGet == NULL) {
+    lv_clipboardGet = caml_named_value("lv_clipboardGet");
+  }
+
+  value v = caml_callback(*lv_clipboardGet, Val_int(regname));
+
+  int ret = 0;
+  // Some
+  if (Is_block(v)) {
+    clipboardArray = Field(v, 0); 
+    int len = Wosize_val(clipboardArray);
+    printf("Got %d lines!\n", len);
+    ret = 0; 
+  } else {
+    ret = 0; 
+  }
+
+  CAMLreturn(ret);
 }
 
 CAMLprim value libvim_vimAutoClosingPairsSet(value acp) {

--- a/test/ClipboardTest.re
+++ b/test/ClipboardTest.re
@@ -3,16 +3,14 @@ open Vim;
 
 let resetBuffer = () => Helpers.resetBuffer("test/testfile.txt");
 
-let makeFun = (s) => (_) => Some([|s|]);
+let makeFun = (s, _) => Some([|s|]);
 
 describe("Clipboard", ({describe, _}) => {
-
   describe("override", ({test, _}) => {
-
     test("None should use default behavior", ({expect, _}) => {
       let buf = resetBuffer();
 
-      Clipboard.setProvider((_) => None);
+      Clipboard.setProvider(_ => None);
 
       input("y");
       input("y");
@@ -22,11 +20,11 @@ describe("Clipboard", ({describe, _}) => {
 
       expect.string(line).toEqual("This is the first line of a test file");
     });
-    
+
     test("return single line", ({expect, _}) => {
       let buf = resetBuffer();
 
-      Clipboard.setProvider((_) => Some([|"a"|]));
+      Clipboard.setProvider(_ => Some([|"a"|]));
 
       input("y");
       input("y");
@@ -36,11 +34,11 @@ describe("Clipboard", ({describe, _}) => {
 
       expect.string(line).toEqual("a");
     });
-    
+
     test("return multiple lines", ({expect, _}) => {
       let buf = resetBuffer();
 
-      Clipboard.setProvider((_) => Some([|"a", "b", "c"|]));
+      Clipboard.setProvider(_ => Some([|"a", "b", "c"|]));
 
       input("y");
       input("y");
@@ -60,7 +58,6 @@ describe("Clipboard", ({describe, _}) => {
 
   describe("garbage collection", ({test, _}) => {
     test("clipboard function should not get collected", ({expect, _}) => {
-      
       let f = makeFun("a");
 
       let finalizeCount = ref(0);
@@ -73,13 +70,14 @@ describe("Clipboard", ({describe, _}) => {
 
       Gc.full_major();
 
-      print_endline ("finalise count: " ++ string_of_int(finalizeCount^));
+      print_endline("finalise count: " ++ string_of_int(finalizeCount^));
 
       expect.int(finalizeCount^).toBe(0);
     });
-    
-    test("clipboard function should be collected if it is overridden", ({expect, _}) => {
-      
+
+    test(
+      "clipboard function should be collected if it is overridden",
+      ({expect, _}) => {
       let f0 = makeFun("a");
       let f1 = makeFun("b");
 
@@ -88,7 +86,7 @@ describe("Clipboard", ({describe, _}) => {
       Clipboard.setProvider(f0);
 
       Gc.finalise_last(() => incr(finalizeCount), f0);
-      
+
       Clipboard.setProvider(f1);
 
       Gc.full_major();

--- a/test/ClipboardTest.re
+++ b/test/ClipboardTest.re
@@ -6,6 +6,58 @@ let resetBuffer = () => Helpers.resetBuffer("test/testfile.txt");
 let makeFun = (s) => (_) => Some([|s|]);
 
 describe("Clipboard", ({describe, _}) => {
+
+  describe("override", ({test, _}) => {
+
+    test("None should use default behavior", ({expect, _}) => {
+      let buf = resetBuffer();
+
+      Clipboard.setProvider((_) => None);
+
+      input("y");
+      input("y");
+      input("p");
+
+      let line = Buffer.getLine(buf, 1);
+
+      expect.string(line).toEqual("This is the first line of a test file");
+    });
+    
+    test("return single line", ({expect, _}) => {
+      let buf = resetBuffer();
+
+      Clipboard.setProvider((_) => Some([|"a"|]));
+
+      input("y");
+      input("y");
+      input("P");
+
+      let line = Buffer.getLine(buf, 1);
+
+      expect.string(line).toEqual("a");
+    });
+    
+    test("return multiple lines", ({expect, _}) => {
+      let buf = resetBuffer();
+
+      Clipboard.setProvider((_) => Some([|"a", "b", "c"|]));
+
+      input("y");
+      input("y");
+      input("P");
+
+      let line1 = Buffer.getLine(buf, 1);
+      let line2 = Buffer.getLine(buf, 2);
+      let line3 = Buffer.getLine(buf, 3);
+      let line4 = Buffer.getLine(buf, 4);
+
+      expect.string(line1).toEqual("a");
+      expect.string(line2).toEqual("b");
+      expect.string(line3).toEqual("c");
+      expect.string(line4).toEqual("This is the first line of a test file");
+    });
+  });
+
   describe("garbage collection", ({test, _}) => {
     test("clipboard function should not get collected", ({expect, _}) => {
       

--- a/test/ClipboardTest.re
+++ b/test/ClipboardTest.re
@@ -62,15 +62,11 @@ describe("Clipboard", ({describe, _}) => {
 
       let finalizeCount = ref(0);
 
-      print_endline("setting provider...");
       Clipboard.setProvider(f);
-      print_endline("provider set.");
 
       Gc.finalise_last(() => incr(finalizeCount), f);
 
       Gc.full_major();
-
-      print_endline("finalise count: " ++ string_of_int(finalizeCount^));
 
       expect.int(finalizeCount^).toBe(0);
     });

--- a/test/ClipboardTest.re
+++ b/test/ClipboardTest.re
@@ -1,0 +1,47 @@
+open TestFramework;
+open Vim;
+
+let resetBuffer = () => Helpers.resetBuffer("test/testfile.txt");
+
+let makeFun = (s) => (_) => Some([|s|]);
+
+describe("Clipboard", ({describe, _}) => {
+  describe("garbage collection", ({test, _}) => {
+    test("clipboard function should not get collected", ({expect, _}) => {
+      
+      let f = makeFun("a");
+
+      let finalizeCount = ref(0);
+
+      print_endline("setting provider...");
+      Clipboard.setProvider(f);
+      print_endline("provider set.");
+
+      Gc.finalise_last(() => incr(finalizeCount), f);
+
+      Gc.full_major();
+
+      print_endline ("finalise count: " ++ string_of_int(finalizeCount^));
+
+      expect.int(finalizeCount^).toBe(0);
+    });
+    
+    test("clipboard function should be collected if it is overridden", ({expect, _}) => {
+      
+      let f0 = makeFun("a");
+      let f1 = makeFun("b");
+
+      let finalizeCount = ref(0);
+
+      Clipboard.setProvider(f0);
+
+      Gc.finalise_last(() => incr(finalizeCount), f0);
+      
+      Clipboard.setProvider(f1);
+
+      Gc.full_major();
+
+      expect.int(finalizeCount^).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
This integrates with the `vimSetClipboardGetCallback` and provides a ReasonML hook for it - allowing Onivim 2 to customize the behavior when 'pulling' from the clipboard.