### PR TITLE
API: Add unhandled escape callback + test

### DIFF
--- a/src/Listeners.re
+++ b/src/Listeners.re
@@ -38,6 +38,7 @@ let modeChanged: ref(list(modeChangedListener)) = ref([]);
 let quit: ref(list(quitListener)) = ref([]);
 let stopSearchHighlight: ref(list(noopListener)) = ref([]);
 let topLineChanged: ref(list(topLineChangedListener)) = ref([]);
+let unhandledEscape: ref(list(noopListener)) = ref([]);
 let visualRangeChanged: ref(list(visualRangeChangedListener)) = ref([]);
 let windowMovement: ref(list(windowMovementListener)) = ref([]);
 let windowSplit: ref(list(windowSplitListener)) = ref([]);

--- a/src/Vim.re
+++ b/src/Vim.re
@@ -170,6 +170,10 @@ let _onStopSearch = () => {
   queue(() => Event.dispatch((), Listeners.stopSearchHighlight));
 };
 
+let _onUnhandledEscape = () => {
+  queue(() => Event.dispatch((), Listeners.unhandledEscape));
+};
+
 let _clipboardGet = (regname: int) => {
   switch (Clipboard._provider^) {
   | None => None
@@ -184,6 +188,7 @@ let init = () => {
   Callback.register("lv_onDirectoryChanged", _onDirectoryChanged);
   Callback.register("lv_onMessage", _onMessage);
   Callback.register("lv_onQuit", _onQuit);
+  Callback.register("lv_onUnhandledEscape", _onUnhandledEscape);
   Callback.register("lv_onStopSearch", _onStopSearch);
   Callback.register("lv_onWindowMovement", _onWindowMovement);
   Callback.register("lv_onWindowSplit", _onWindowSplit);
@@ -213,6 +218,10 @@ let onMessage = f => {
 
 let onQuit = f => {
   Event.add2(f, Listeners.quit);
+};
+
+let onUnhandledEscape = f => {
+  Event.add(f, Listeners.unhandledEscape);
 };
 
 let onYank = f => {

--- a/src/Vim.rei
+++ b/src/Vim.rei
@@ -54,6 +54,16 @@ by [command(":q")] or [ZZ].
 let onQuit: Listeners.quitListener => Event.unsubscribe;
 
 /**
+[onUnhandledEscape(f)] registers an unhandled escape listener [f].
+
+[f] is called whenver an _unhandled escape_ occurs. This happens, for example,
+if the user presses <esc> while in normal mode, but there is no pending operator.
+
+The default Vim behavior was to 'beep', but UIs might want to handle this differently.
+*/
+let onUnhandledEscape: Listeners.noopListener => Event.unsubscribe;
+
+/**
 [onYank(f)] registers a yank listener [f]
 
 [f] is called whenever a value is 'yanked' to a register -

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -108,6 +108,18 @@ void onQuit(buf_T *buf, int isForced) {
   CAMLreturn0;
 }
 
+void onUnhandledEscape() {
+  CAMLparam0();
+
+  static value *lv_onUnhandledEscape = NULL;
+
+  if (lv_onUnhandledEscape == NULL) {
+    lv_onUnhandledEscape = caml_named_value("lv_onUnhandledEscape");
+  }
+  caml_callback(*lv_onUnhandledEscape, Val_unit);
+  CAMLreturn0;
+}
+
 void onStopSearch(void) {
   CAMLparam0();
 
@@ -252,6 +264,7 @@ CAMLprim value libvim_vimInit(value unit) {
   vimSetMessageCallback(&onMessage);
   vimSetQuitCallback(&onQuit);
   vimSetStopSearchHighlightCallback(&onStopSearch);
+  vimSetUnhandledEscapeCallback(&onUnhandledEscape);
   vimSetWindowMovementCallback(&onWindowMovement);
   vimSetWindowSplitCallback(&onWindowSplit);
   vimSetYankCallback(&onYank);

--- a/test/UnhandledEscapeTest.re
+++ b/test/UnhandledEscapeTest.re
@@ -1,0 +1,29 @@
+open TestFramework;
+
+let resetBuffer = () => Helpers.resetBuffer("test/testfile.txt");
+
+describe("onUnhandledEscape", ({test, _}) => {
+  test("unhandled escape called with no pending operator", ({expect}) => {
+    let _ = resetBuffer();
+
+    let callCount = ref(0);
+    let dispose = Vim.onUnhandledEscape(() => incr(callCount));
+
+    Vim.input("<esc>");
+    expect.int(callCount^).toBe(1);
+
+    dispose();
+  });
+  test("unhandled escape not called when in insert", ({expect}) => {
+    let _ = resetBuffer();
+
+    let callCount = ref(0);
+    let dispose = Vim.onUnhandledEscape(() => incr(callCount));
+
+    Vim.input("i");
+    Vim.input("<esc>");
+    expect.int(callCount^).toBe(0);
+
+    dispose();
+  });
+});


### PR DESCRIPTION
This adds a ReasonML binding for the `setUnhandledEscapeCallback` libvim API