### PR TITLE
Feature - AutoClosingPairs: Move ACP to 'user-space'

### DIFF
--- a/src/AutoClosingPairs.re
+++ b/src/AutoClosingPairs.re
@@ -1,1 +1,67 @@
-let setPairs = Native.vimAutoClosingPairsSet;
+module AutoClosingPair = {
+  type t = {
+    opening: string,
+    closing: string,
+  };
+
+  let create = (~opening, ~closing, ()) => {opening, closing};
+};
+
+type t = {pairs: list(AutoClosingPair.t)};
+
+let empty: t = {pairs: []};
+
+let create: list(AutoClosingPair.t) => t =
+  (p: list(AutoClosingPair.t)) => {pairs: p};
+
+let closingPairs = ref(empty);
+let enabled = ref(false);
+
+let setEnabled = e => enabled := e;
+let getEnabled = () => enabled^;
+
+let setPairs = (acp: t) => {
+  closingPairs := acp;
+};
+
+let isMatchingPair = c => {
+  List.exists((p: AutoClosingPair.t) => p.opening == c, closingPairs^.pairs);
+};
+
+let isOpeningPair = c => {
+  let currentPairs = closingPairs^;
+  List.exists((p: AutoClosingPair.t) => p.opening == c, currentPairs.pairs);
+};
+
+let isClosingPair = c => {
+  let currentPairs = closingPairs^;
+  List.exists((p: AutoClosingPair.t) => p.closing == c, currentPairs.pairs);
+};
+
+let getByOpeningPair = c => {
+  let currentPairs = closingPairs^;
+  let matches =
+    List.filter(
+      (p: AutoClosingPair.t) => p.opening == c,
+      currentPairs.pairs,
+    );
+
+  switch (matches) {
+  | [hd, ..._] => hd
+  | [] => failwith("No matching pair: " ++ c)
+  };
+};
+
+let isBetweenPairs = (line, position) => {
+  let len = String.length(line);
+  if (position > 0 && position < len) {
+    List.exists(
+      (p: AutoClosingPair.t) =>
+        p.opening == String.sub(line, position - 1, 1)
+        && p.closing == String.sub(line, position, 1),
+      closingPairs^.pairs,
+    );
+  } else {
+    false;
+  };
+};

--- a/src/Native.re
+++ b/src/Native.re
@@ -6,9 +6,6 @@ external vimCommand: string => unit = "libvim_vimCommand";
 
 external vimGetMode: unit => Types.mode = "libvim_vimGetMode";
 
-external vimAutoClosingPairsSet: Types.autoClosingPairs => unit =
-  "libvim_vimAutoClosingPairsSet";
-
 external vimBufferOpen: string => buffer = "libvim_vimBufferOpen";
 external vimBufferGetId: buffer => int = "libvim_vimBufferGetId";
 external vimBufferGetById: int => option(buffer) = "libvim_vimBufferGetById";
@@ -38,10 +35,6 @@ external vimCursorGetColumn: unit => int = "libvim_vimCursorGetColumn";
 external vimCursorSetPosition: (int, int) => unit =
   "libvim_vimCursorSetPosition";
 
-external vimOptionSetAutoClosingPairs: bool => unit =
-  "libvim_vimOptionSetAutoClosingPairs";
-external vimOptionGetAutoClosingPairs: unit => bool =
-  "libvim_vimOptionGetAutoClosingPairs";
 external vimOptionSetTabSize: int => unit = "libvim_vimOptionSetTabSize";
 external vimOptionSetInsertSpaces: bool => unit =
   "libvim_vimOptionSetInsertSpaces";
@@ -54,6 +47,9 @@ external vimSearchGetMatchingPair: unit => option((int, int)) =
 
 external vimSearchGetHighlights: (int, int) => array((int, int, int, int)) =
   "libvim_vimSearchGetHighlights";
+
+external vimUndoSaveCursor: unit => unit = "libvim_vimUndoSaveCursor";
+external vimUndoSaveRegion: (int, int) => unit = "libvim_vimUndoSaveRegion";
 
 external vimVisualGetRange: unit => (int, int, int, int) =
   "libvim_vimVisualGetRange";

--- a/src/Options.re
+++ b/src/Options.re
@@ -1,9 +1,9 @@
 type t = Native.buffer;
 
-let setAutoClosingPairs = Native.vimOptionSetAutoClosingPairs;
+let setAutoClosingPairs = AutoClosingPairs.setEnabled;
 let setTabSize = Native.vimOptionSetTabSize;
 let setInsertSpaces = Native.vimOptionSetInsertSpaces;
 
-let getAutoClosingPairs = Native.vimOptionGetAutoClosingPairs;
+let getAutoClosingPairs = AutoClosingPairs.getEnabled;
 let getTabSize = Native.vimOptionGetTabSize;
 let getInsertSpaces = Native.vimOptionGetInsertSpaces;

--- a/src/Types.re
+++ b/src/Types.re
@@ -1,16 +1,5 @@
 type buffer;
 
-module AutoClosingPair = {
-  type t = {
-    opening: char,
-    closing: char,
-  };
-
-  let create = (~opening, ~closing, ()) => {opening, closing};
-};
-
-type autoClosingPairs = array(AutoClosingPair.t);
-
 type clipboardProvider = int => option(array(string));
 
 type mode =

--- a/src/Undo.re
+++ b/src/Undo.re
@@ -1,0 +1,2 @@
+let saveCursor = Native.vimUndoSaveCursor;
+let saveRegion = Native.vimUndoSaveRegion;

--- a/src/Vim.re
+++ b/src/Vim.re
@@ -202,37 +202,38 @@ let init = () => {
 };
 
 let input = (v: string) => {
-  checkAndUpdateState(() =>
+  checkAndUpdateState(()
     // Special auto-closing pairs handling...
-    if (AutoClosingPairs.getEnabled() && Mode.getCurrent() == Types.Insert) {
-      let isBetweenPairs = {
-        let position = Cursor.getPosition();
-        let line = Buffer.getLine(Buffer.getCurrent(), position.line);
-        AutoClosingPairs.isBetweenPairs(line, position.column);
-      };
+    =>
+      if (AutoClosingPairs.getEnabled() && Mode.getCurrent() == Types.Insert) {
+        let isBetweenPairs = {
+          let position = Cursor.getPosition();
+          let line = Buffer.getLine(Buffer.getCurrent(), position.line);
+          AutoClosingPairs.isBetweenPairs(line, position.column);
+        };
 
-      if (v == "<BS>" && isBetweenPairs) {
-        Native.vimInput("<DEL>");
-        Native.vimInput("<BS>");
-      } else if (v == "<CR>" && isBetweenPairs) {
-        Native.vimInput("<CR>");
-        Native.vimInput("<CR>");
-        Native.vimInput("<UP>");
-        Native.vimInput("<TAB>");
-      } else if (AutoClosingPairs.isOpeningPair(v)) {
-        let pair = AutoClosingPairs.getByOpeningPair(v);
-        Native.vimInput(v);
-        Native.vimInput(pair.closing);
-        Native.vimInput("<LEFT>");
-      } else if (AutoClosingPairs.isClosingPair(v) && isBetweenPairs) {
-        Native.vimInput("<RIGHT>");
+        if (v == "<BS>" && isBetweenPairs) {
+          Native.vimInput("<DEL>");
+          Native.vimInput("<BS>");
+        } else if (v == "<CR>" && isBetweenPairs) {
+          Native.vimInput("<CR>");
+          Native.vimInput("<CR>");
+          Native.vimInput("<UP>");
+          Native.vimInput("<TAB>");
+        } else if (AutoClosingPairs.isOpeningPair(v)) {
+          let pair = AutoClosingPairs.getByOpeningPair(v);
+          Native.vimInput(v);
+          Native.vimInput(pair.closing);
+          Native.vimInput("<LEFT>");
+        } else if (AutoClosingPairs.isClosingPair(v) && isBetweenPairs) {
+          Native.vimInput("<RIGHT>");
+        } else {
+          Native.vimInput(v);
+        };
       } else {
         Native.vimInput(v);
-      };
-    } else {
-      Native.vimInput(v);
-    }
-  );
+      }
+    );
 };
 
 let command = v => {

--- a/src/bindings.c
+++ b/src/bindings.c
@@ -637,6 +637,25 @@ CAMLprim value libvim_vimWindowSetTopLeft(value top, value left) {
   return Val_unit;
 }
 
+CAMLprim value libvim_vimUndoSaveCursor(value unit) {
+  CAMLparam0();
+
+  vimUndoSaveCursor();
+
+  CAMLreturn(Val_unit);
+}
+
+CAMLprim value libvim_vimUndoSaveRegion(value startLine, value endLine) {
+  CAMLparam2(startLine, endLine);
+
+  int start = Int_val(startLine);
+  int end = Int_val(endLine);
+
+  vimUndoSaveRegion(start, end);
+
+  CAMLreturn(Val_unit);
+}
+
 CAMLprim value libvim_vimVisualGetType(value unit) {
   int ret;
   char v = vimVisualGetType();

--- a/test/AutoClosingPairsTest.re
+++ b/test/AutoClosingPairsTest.re
@@ -35,9 +35,12 @@ describe("AutoClosingPairs", ({test, _}) => {
   test("single acp", ({expect}) => {
     let b = resetBuffer();
     Options.setAutoClosingPairs(true);
-    AutoClosingPairs.setPairs([|
-      Types.AutoClosingPair.create(~opening='[', ~closing=']', ()),
-    |]);
+    AutoClosingPairs.create(
+      AutoClosingPairs.[
+        AutoClosingPair.create(~opening="[", ~closing="]", ()),
+      ],
+    )
+    |> AutoClosingPairs.setPairs;
 
     input("O");
     input("[");
@@ -49,15 +52,76 @@ describe("AutoClosingPairs", ({test, _}) => {
     expect.string(line).toEqual("[(\"{]");
   });
 
+  test("isBetweenPairs", ({expect}) => {
+    let b = resetBuffer();
+    Options.setAutoClosingPairs(true);
+    AutoClosingPairs.create(
+      AutoClosingPairs.[
+        AutoClosingPair.create(~opening="[", ~closing="]", ()),
+      ],
+    )
+    |> AutoClosingPairs.setPairs;
+
+    input("O");
+    input("[");
+
+    let line = Buffer.getLine(b, 1);
+    let position = Cursor.getPosition();
+    expect.bool(AutoClosingPairs.isBetweenPairs(line, position.column)).toBe(
+      true,
+    );
+  });
+
+  test("backspace between pairs", ({expect}) => {
+    let b = resetBuffer();
+    Options.setAutoClosingPairs(true);
+    AutoClosingPairs.create(
+      AutoClosingPairs.[
+        AutoClosingPair.create(~opening="[", ~closing="]", ()),
+      ],
+    )
+    |> AutoClosingPairs.setPairs;
+
+    input("O");
+    input("[");
+    input("<BS>");
+
+    let line = Buffer.getLine(b, 1);
+    expect.string(line).toEqual("");
+  });
+
+  test("pass-through between pairs", ({expect}) => {
+    let b = resetBuffer();
+    Options.setAutoClosingPairs(true);
+    AutoClosingPairs.create(
+      AutoClosingPairs.[
+        AutoClosingPair.create(~opening="[", ~closing="]", ()),
+      ],
+    )
+    |> AutoClosingPairs.setPairs;
+
+    input("O");
+    input("[");
+    input("]");
+
+    let line = Buffer.getLine(b, 1);
+    let position = Cursor.getPosition();
+    expect.string(line).toEqual("[]");
+    expect.int(position.column).toBe(2);
+  });
+
   test("multiple acp", ({expect}) => {
     let b = resetBuffer();
     Options.setAutoClosingPairs(true);
-    AutoClosingPairs.setPairs([|
-      Types.AutoClosingPair.create(~opening='[', ~closing=']', ()),
-      Types.AutoClosingPair.create(~opening='{', ~closing='}', ()),
-      Types.AutoClosingPair.create(~opening='(', ~closing=')', ()),
-      Types.AutoClosingPair.create(~opening='"', ~closing='"', ()),
-    |]);
+    AutoClosingPairs.create(
+      AutoClosingPairs.[
+        AutoClosingPair.create(~opening="[", ~closing="]", ()),
+        AutoClosingPair.create(~opening="{", ~closing="}", ()),
+        AutoClosingPair.create(~opening="(", ~closing=")", ()),
+        AutoClosingPair.create(~opening="\"", ~closing="\"", ()),
+      ],
+    )
+    |> AutoClosingPairs.setPairs;
 
     input("O");
     input("[");


### PR DESCRIPTION
This implementation fixes a few issues with the `libvim`-side ACP