### PR TITLE
Fix pass-through when closing and opening character are the same

### DIFF
--- a/src/AutoClosingPairs.re
+++ b/src/AutoClosingPairs.re
@@ -66,13 +66,10 @@ let isBetweenPairs = (line, position) => {
   };
 };
 
-let isNextCharacterClosing = (line, position) => {
+let doesNextCharacterMatch = (line, position, s) => {
   let len = String.length(line);
   if (position > 0 && position < len) {
-    List.exists(
-      (p: AutoClosingPair.t) => p.closing == String.sub(line, position, 1),
-      closingPairs^.pairs,
-    );
+    s == String.sub(line, position, 1);
   } else {
     false;
   };

--- a/src/Vim.re
+++ b/src/Vim.re
@@ -212,10 +212,10 @@ let input = (v: string) => {
           AutoClosingPairs.isBetweenPairs(line, position.column);
         };
 
-        let isNextCharacterClosing = () => {
+        let doesNextCharacterMatch = s => {
           let position = Cursor.getPosition();
           let line = Buffer.getLine(Buffer.getCurrent(), position.line);
-          AutoClosingPairs.isNextCharacterClosing(line, position.column);
+          AutoClosingPairs.doesNextCharacterMatch(line, position.column, s);
         };
         if (v == "<BS>" && isBetweenPairs()) {
           Native.vimInput("<DEL>");
@@ -225,14 +225,14 @@ let input = (v: string) => {
           Native.vimInput("<CR>");
           Native.vimInput("<UP>");
           Native.vimInput("<TAB>");
+        } else if (AutoClosingPairs.isClosingPair(v)
+                   && doesNextCharacterMatch(v)) {
+          Native.vimInput("<RIGHT>");
         } else if (AutoClosingPairs.isOpeningPair(v)) {
           let pair = AutoClosingPairs.getByOpeningPair(v);
           Native.vimInput(v);
           Native.vimInput(pair.closing);
           Native.vimInput("<LEFT>");
-        } else if (AutoClosingPairs.isClosingPair(v)
-                   && isNextCharacterClosing()) {
-          Native.vimInput("<RIGHT>");
         } else {
           Native.vimInput(v);
         };

--- a/test/AutoClosingPairsTest.re
+++ b/test/AutoClosingPairsTest.re
@@ -131,6 +131,29 @@ describe("AutoClosingPairs", ({test, _}) => {
     expect.int(position.column).toBe(3);
   });
 
+  test(
+    "pass-through not between pairs, with same begin/end pair", ({expect}) => {
+    let b = resetBuffer();
+    Options.setAutoClosingPairs(true);
+    let quote = {|"|};
+    AutoClosingPairs.create(
+      AutoClosingPairs.[
+        AutoClosingPair.create(~opening=quote, ~closing=quote, ()),
+      ],
+    )
+    |> AutoClosingPairs.setPairs;
+
+    input("O");
+    input(quote);
+    input("x");
+    input(quote);
+
+    let line = Buffer.getLine(b, 1);
+    let position = Cursor.getPosition();
+    expect.string(line).toEqual({|"x"|});
+    expect.int(position.column).toBe(3);
+  });
+
   test("can insert closing pair", ({expect}) => {
     let b = resetBuffer();
     Options.setAutoClosingPairs(true);


### PR DESCRIPTION
Fix another bug with 'pass-through' auto-closing pairs.

The bug was, when working with a line like:
`"a|"` (where `|` is the cursor position) - pressing `"` would insert a pair, resulting in:
`"a|"""`
whereas, it should've passed-through in that case, with an expected value of:
`"a"|`

The issue was that our precedence of auto-closing pair evaluation was wrong - we need to check for the pass-through case before the insert pair case.