### PR TITLE
Feature - ACP: Add '~allowBefore' option

### DIFF
--- a/test/AutoClosingPairsTest.re
+++ b/test/AutoClosingPairsTest.re
@@ -177,6 +177,7 @@ describe("AutoClosingPairs", ({test, _}) => {
     let b = resetBuffer();
     Options.setAutoClosingPairs(true);
     AutoClosingPairs.create(
+      ~allowBefore=["]", "}", ")", "\""],
       AutoClosingPairs.[
         AutoClosingPair.create(~opening="[", ~closing="]", ()),
         AutoClosingPair.create(~opening="{", ~closing="}", ()),


### PR DESCRIPTION
This allows a list of characters to allow auto-closing pairs (supporting the `autoCloseBefore` property from the language information).