### PR TITLE
API - Input: Add auto-closing pair as an option

### DIFF
--- a/esy.lock/.gitattributes
+++ b/esy.lock/.gitattributes
@@ -1,3 +1,3 @@
 
 # Set eol to LF so files aren't converted to CRLF-eol on Windows.
-* text eol=lf linguist-generated
+* text eol=lf

--- a/esy.lock/index.json
+++ b/esy.lock/index.json
@@ -16,7 +16,7 @@
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@reason-native/pastel@0.2.3@d41d8cd9",
         "@reason-native/console@0.1.0@d41d8cd9",
-        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:2.0.1@5dc56bd0",
+        "@opam/re@opam:1.9.0@d4d5e13d", "@opam/dune@opam:2.1.1@9d89dcce",
         "@opam/atdgen@opam:2.0.0@46af0360",
         "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
@@ -36,8 +36,8 @@
         "refmterr@3.3.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
         "libvim@8.10869.29@d41d8cd9",
         "editor-core-types@github:onivim/editor-core-types#3ee552a@d41d8cd9",
-        "@opam/dune-configurator@opam:2.0.1@6963c1e8",
-        "@opam/dune@opam:2.0.1@5dc56bd0", "@esy-ocaml/reason@3.5.2@d41d8cd9"
+        "@opam/dune-configurator@opam:2.1.1@e8ac3890",
+        "@opam/dune@opam:2.1.1@9d89dcce", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
     },
@@ -81,7 +81,7 @@
       "overrides": [],
       "dependencies": [
         "refmterr@3.3.0@d41d8cd9", "ocaml@4.7.1004@d41d8cd9",
-        "@opam/dune@opam:2.0.1@5dc56bd0", "@esy-ocaml/reason@3.5.2@d41d8cd9"
+        "@opam/dune@opam:2.1.1@9d89dcce", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": [ "ocaml@4.7.1004@d41d8cd9" ]
     },
@@ -98,7 +98,7 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/re@opam:1.9.0@d4d5e13d",
-        "@opam/dune@opam:2.0.1@5dc56bd0", "@esy-ocaml/reason@3.5.2@d41d8cd9"
+        "@opam/dune@opam:2.1.1@9d89dcce", "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
     },
@@ -114,7 +114,7 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.0.1@5dc56bd0",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.1.1@9d89dcce",
         "@esy-ocaml/reason@3.5.2@d41d8cd9"
       ],
       "devDependencies": []
@@ -138,13 +138,13 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/easy-format@opam:1.3.1@54402780",
-        "@opam/dune@opam:2.0.1@5dc56bd0", "@opam/cppo@opam:1.6.6@f4f83858",
+        "@opam/dune@opam:2.1.1@9d89dcce", "@opam/cppo@opam:1.6.6@f4f83858",
         "@opam/biniou@opam:1.2.0@b5796419",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/easy-format@opam:1.3.1@54402780",
-        "@opam/dune@opam:2.0.1@5dc56bd0", "@opam/biniou@opam:1.2.0@b5796419"
+        "@opam/dune@opam:2.1.1@9d89dcce", "@opam/biniou@opam:1.2.0@b5796419"
       ]
     },
     "@opam/seq@opam:base@d8d7de1d": {
@@ -184,11 +184,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.0.1@5dc56bd0",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.1.1@9d89dcce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.0.1@5dc56bd0"
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.1.1@9d89dcce"
       ]
     },
     "@opam/re@opam:1.9.0@d4d5e13d": {
@@ -210,11 +210,11 @@
       "overrides": [],
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
-        "@opam/dune@opam:2.0.1@5dc56bd0", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.1.1@9d89dcce", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/seq@opam:base@d8d7de1d",
-        "@opam/dune@opam:2.0.1@5dc56bd0"
+        "@opam/dune@opam:2.1.1@9d89dcce"
       ]
     },
     "@opam/ppx_derivers@opam:1.2.1@ecf0aa45": {
@@ -235,11 +235,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.0.1@5dc56bd0",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.1.1@9d89dcce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.0.1@5dc56bd0"
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.1.1@9d89dcce"
       ]
     },
     "@opam/ocamlfind@opam:1.8.1@ff07b0f9": {
@@ -318,12 +318,12 @@
       "dependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
-        "@opam/dune@opam:2.0.1@5dc56bd0", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune@opam:2.1.1@9d89dcce", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
         "ocaml@4.7.1004@d41d8cd9", "@opam/result@opam:1.4@dc720aef",
         "@opam/ppx_derivers@opam:1.2.1@ecf0aa45",
-        "@opam/dune@opam:2.0.1@5dc56bd0"
+        "@opam/dune@opam:2.1.1@9d89dcce"
       ]
     },
     "@opam/merlin-extend@opam:0.5@a5dd7d4b": {
@@ -344,11 +344,11 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.0.1@5dc56bd0",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.1.1@9d89dcce",
         "@opam/cppo@opam:1.6.6@f4f83858", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.0.1@5dc56bd0"
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.1.1@9d89dcce"
       ]
     },
     "@opam/menhir@opam:20190924@004407ff": {
@@ -424,71 +424,71 @@
         "@opam/jbuilder@opam:1.0+beta20.2@053ddcf2"
       ]
     },
-    "@opam/dune-private-libs@opam:2.0.1@d5d5e717": {
-      "id": "@opam/dune-private-libs@opam:2.0.1@d5d5e717",
+    "@opam/dune-private-libs@opam:2.1.1@63d85af2": {
+      "id": "@opam/dune-private-libs@opam:2.1.1@63d85af2",
       "name": "@opam/dune-private-libs",
-      "version": "opam:2.0.1",
+      "version": "opam:2.1.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/e0/e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7#sha256:e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7",
-          "archive:https://github.com/ocaml/dune/releases/download/2.0.1/dune-2.0.1.tbz#sha256:e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7"
+          "archive:https://opam.ocaml.org/cache/sha256/b1/b14417016fa0901c0b04b8474aa9e5eafaadb298c4dc422899b7f9e8bcb7aa7c#sha256:b14417016fa0901c0b04b8474aa9e5eafaadb298c4dc422899b7f9e8bcb7aa7c",
+          "archive:https://github.com/ocaml/dune/releases/download/2.1.1/dune-2.1.1.tbz#sha256:b14417016fa0901c0b04b8474aa9e5eafaadb298c4dc422899b7f9e8bcb7aa7c"
         ],
         "opam": {
           "name": "dune-private-libs",
-          "version": "2.0.1",
-          "path": "esy.lock/opam/dune-private-libs.2.0.1"
+          "version": "2.1.1",
+          "path": "esy.lock/opam/dune-private-libs.2.1.1"
         }
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.0.1@5dc56bd0",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.1.1@9d89dcce",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.0.1@5dc56bd0"
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.1.1@9d89dcce"
       ]
     },
-    "@opam/dune-configurator@opam:2.0.1@6963c1e8": {
-      "id": "@opam/dune-configurator@opam:2.0.1@6963c1e8",
+    "@opam/dune-configurator@opam:2.1.1@e8ac3890": {
+      "id": "@opam/dune-configurator@opam:2.1.1@e8ac3890",
       "name": "@opam/dune-configurator",
-      "version": "opam:2.0.1",
+      "version": "opam:2.1.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/e0/e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7#sha256:e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7",
-          "archive:https://github.com/ocaml/dune/releases/download/2.0.1/dune-2.0.1.tbz#sha256:e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7"
+          "archive:https://opam.ocaml.org/cache/sha256/b1/b14417016fa0901c0b04b8474aa9e5eafaadb298c4dc422899b7f9e8bcb7aa7c#sha256:b14417016fa0901c0b04b8474aa9e5eafaadb298c4dc422899b7f9e8bcb7aa7c",
+          "archive:https://github.com/ocaml/dune/releases/download/2.1.1/dune-2.1.1.tbz#sha256:b14417016fa0901c0b04b8474aa9e5eafaadb298c4dc422899b7f9e8bcb7aa7c"
         ],
         "opam": {
           "name": "dune-configurator",
-          "version": "2.0.1",
-          "path": "esy.lock/opam/dune-configurator.2.0.1"
+          "version": "2.1.1",
+          "path": "esy.lock/opam/dune-configurator.2.1.1"
         }
       },
       "overrides": [],
       "dependencies": [
-        "@opam/dune-private-libs@opam:2.0.1@d5d5e717",
-        "@opam/dune@opam:2.0.1@5dc56bd0", "@esy-ocaml/substs@0.0.1@d41d8cd9"
+        "@opam/dune-private-libs@opam:2.1.1@63d85af2",
+        "@opam/dune@opam:2.1.1@9d89dcce", "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "@opam/dune-private-libs@opam:2.0.1@d5d5e717",
-        "@opam/dune@opam:2.0.1@5dc56bd0"
+        "@opam/dune-private-libs@opam:2.1.1@63d85af2",
+        "@opam/dune@opam:2.1.1@9d89dcce"
       ]
     },
-    "@opam/dune@opam:2.0.1@5dc56bd0": {
-      "id": "@opam/dune@opam:2.0.1@5dc56bd0",
+    "@opam/dune@opam:2.1.1@9d89dcce": {
+      "id": "@opam/dune@opam:2.1.1@9d89dcce",
       "name": "@opam/dune",
-      "version": "opam:2.0.1",
+      "version": "opam:2.1.1",
       "source": {
         "type": "install",
         "source": [
-          "archive:https://opam.ocaml.org/cache/sha256/e0/e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7#sha256:e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7",
-          "archive:https://github.com/ocaml/dune/releases/download/2.0.1/dune-2.0.1.tbz#sha256:e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7"
+          "archive:https://opam.ocaml.org/cache/sha256/b1/b14417016fa0901c0b04b8474aa9e5eafaadb298c4dc422899b7f9e8bcb7aa7c#sha256:b14417016fa0901c0b04b8474aa9e5eafaadb298c4dc422899b7f9e8bcb7aa7c",
+          "archive:https://github.com/ocaml/dune/releases/download/2.1.1/dune-2.1.1.tbz#sha256:b14417016fa0901c0b04b8474aa9e5eafaadb298c4dc422899b7f9e8bcb7aa7c"
         ],
         "opam": {
           "name": "dune",
-          "version": "2.0.1",
-          "path": "esy.lock/opam/dune.2.0.1"
+          "version": "2.1.1",
+          "path": "esy.lock/opam/dune.2.1.1"
         }
       },
       "overrides": [],
@@ -520,12 +520,12 @@
       },
       "overrides": [],
       "dependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.0.1@5dc56bd0",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.1.1@9d89dcce",
         "@opam/base-unix@opam:base@87d0b2eb",
         "@esy-ocaml/substs@0.0.1@d41d8cd9"
       ],
       "devDependencies": [
-        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.0.1@5dc56bd0",
+        "ocaml@4.7.1004@d41d8cd9", "@opam/dune@opam:2.1.1@9d89dcce",
         "@opam/base-unix@opam:base@87d0b2eb"
       ]
     },
@@ -748,7 +748,7 @@
         "@opam/ocaml-migrate-parsetree@opam:1.3.1@8bfb3f95",
         "@opam/merlin-extend@opam:0.5@a5dd7d4b",
         "@opam/menhir@opam:20190924@004407ff",
-        "@opam/dune@opam:2.0.1@5dc56bd0"
+        "@opam/dune@opam:2.1.1@9d89dcce"
       ],
       "devDependencies": []
     }

--- a/esy.lock/opam/dune-configurator.2.1.1/opam
+++ b/esy.lock/opam/dune-configurator.2.1.1/opam
@@ -35,9 +35,9 @@ build: [
   ]
 ]
 url {
-  src: "https://github.com/ocaml/dune/releases/download/2.0.1/dune-2.0.1.tbz"
+  src: "https://github.com/ocaml/dune/releases/download/2.1.1/dune-2.1.1.tbz"
   checksum: [
-    "sha256=e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7"
-    "sha512=8c973ccfa1de0ff7173e17dac74ea850446a057866d47c7a100b271c7e440d5e607f1bfaa8fa5b756e0439492276e8c6615fac30cbff9ea900dc8e891f7ba4d3"
+    "sha256=b14417016fa0901c0b04b8474aa9e5eafaadb298c4dc422899b7f9e8bcb7aa7c"
+    "sha512=605019ed9555ae669fd3e27518637a7e31e5935d4b0db54d6b066e0e1d11ef163b57eacec50f1f061baa808548c2b9017b8b1c44e3e78e50bbf27a572408e18f"
   ]
 }

--- a/esy.lock/opam/dune-private-libs.2.1.1/opam
+++ b/esy.lock/opam/dune-private-libs.2.1.1/opam
@@ -17,7 +17,7 @@ doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
   "dune" {>= "2.0"}
-  "ocaml" {>= "4.06"}
+  "ocaml" {>= "4.07"}
 ]
 dev-repo: "git+https://github.com/ocaml/dune.git"
 build: [
@@ -34,9 +34,9 @@ build: [
   ]
 ]
 url {
-  src: "https://github.com/ocaml/dune/releases/download/2.0.1/dune-2.0.1.tbz"
+  src: "https://github.com/ocaml/dune/releases/download/2.1.1/dune-2.1.1.tbz"
   checksum: [
-    "sha256=e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7"
-    "sha512=8c973ccfa1de0ff7173e17dac74ea850446a057866d47c7a100b271c7e440d5e607f1bfaa8fa5b756e0439492276e8c6615fac30cbff9ea900dc8e891f7ba4d3"
+    "sha256=b14417016fa0901c0b04b8474aa9e5eafaadb298c4dc422899b7f9e8bcb7aa7c"
+    "sha512=605019ed9555ae669fd3e27518637a7e31e5935d4b0db54d6b066e0e1d11ef163b57eacec50f1f061baa808548c2b9017b8b1c44e3e78e50bbf27a572408e18f"
   ]
 }

--- a/esy.lock/opam/dune.2.1.1/opam
+++ b/esy.lock/opam/dune.2.1.1/opam
@@ -26,7 +26,7 @@ homepage: "https://github.com/ocaml/dune"
 doc: "https://dune.readthedocs.io/"
 bug-reports: "https://github.com/ocaml/dune/issues"
 depends: [
-  ("ocaml" {>= "4.06"} | ("ocaml" {< "4.06~~"} & "ocamlfind-secondary"))
+  "ocaml" {>= "4.07"}
   "base-unix"
   "base-threads"
 ]
@@ -43,9 +43,9 @@ build: [
   ["./dune.exe" "build" "-p" name "--profile" "dune-bootstrap" "-j" jobs]
 ]
 url {
-  src: "https://github.com/ocaml/dune/releases/download/2.0.1/dune-2.0.1.tbz"
+  src: "https://github.com/ocaml/dune/releases/download/2.1.1/dune-2.1.1.tbz"
   checksum: [
-    "sha256=e04090c846f005f1cc02c390e963a7efe74c653ce2c5c7fd2e7e30a06ceadcb7"
-    "sha512=8c973ccfa1de0ff7173e17dac74ea850446a057866d47c7a100b271c7e440d5e607f1bfaa8fa5b756e0439492276e8c6615fac30cbff9ea900dc8e891f7ba4d3"
+    "sha256=b14417016fa0901c0b04b8474aa9e5eafaadb298c4dc422899b7f9e8bcb7aa7c"
+    "sha512=605019ed9555ae669fd3e27518637a7e31e5935d4b0db54d6b066e0e1d11ef163b57eacec50f1f061baa808548c2b9017b8b1c44e3e78e50bbf27a572408e18f"
   ]
 }

--- a/src/AutoClosingPairs.re
+++ b/src/AutoClosingPairs.re
@@ -27,16 +27,6 @@ let create = (~allowBefore=[], p: list(AutoClosingPair.t)) => {
   {pairs: p, before: hash};
 };
 
-/*let closingPairs = ref(empty);
-  let enabled = ref(false);
-
-  let setEnabled = e => enabled := e;
-  let getEnabled = () => enabled^;
-
-  let setPairs = (acp: t) => {
-    closingPairs := acp;
-  };*/
-
 let isMatchingPair = (c, closingPairs: t) => {
   List.exists((p: AutoClosingPair.t) => p.opening == c, closingPairs.pairs);
 };

--- a/src/AutoClosingPairs.re
+++ b/src/AutoClosingPairs.re
@@ -27,36 +27,33 @@ let create = (~allowBefore=[], p: list(AutoClosingPair.t)) => {
   {pairs: p, before: hash};
 };
 
-let closingPairs = ref(empty);
-let enabled = ref(false);
+/*let closingPairs = ref(empty);
+  let enabled = ref(false);
 
-let setEnabled = e => enabled := e;
-let getEnabled = () => enabled^;
+  let setEnabled = e => enabled := e;
+  let getEnabled = () => enabled^;
 
-let setPairs = (acp: t) => {
-  closingPairs := acp;
+  let setPairs = (acp: t) => {
+    closingPairs := acp;
+  };*/
+
+let isMatchingPair = (c, closingPairs: t) => {
+  List.exists((p: AutoClosingPair.t) => p.opening == c, closingPairs.pairs);
 };
 
-let isMatchingPair = c => {
-  List.exists((p: AutoClosingPair.t) => p.opening == c, closingPairs^.pairs);
+let isOpeningPair = (c, closingPairs: t) => {
+  List.exists((p: AutoClosingPair.t) => p.opening == c, closingPairs.pairs);
 };
 
-let isOpeningPair = c => {
-  let currentPairs = closingPairs^;
-  List.exists((p: AutoClosingPair.t) => p.opening == c, currentPairs.pairs);
+let isClosingPair = (c, closingPairs: t) => {
+  List.exists((p: AutoClosingPair.t) => p.closing == c, closingPairs.pairs);
 };
 
-let isClosingPair = c => {
-  let currentPairs = closingPairs^;
-  List.exists((p: AutoClosingPair.t) => p.closing == c, currentPairs.pairs);
-};
-
-let getByOpeningPair = c => {
-  let currentPairs = closingPairs^;
+let getByOpeningPair = (c, closingPairs: t) => {
   let matches =
     List.filter(
       (p: AutoClosingPair.t) => p.opening == c,
-      currentPairs.pairs,
+      closingPairs.pairs,
     );
 
   switch (matches) {
@@ -65,7 +62,7 @@ let getByOpeningPair = c => {
   };
 };
 
-let isBetweenPairs = (line, index) => {
+let isBetweenPairs = (line, index, closingPairs) => {
   let index = Index.toZeroBased(index);
   let len = String.length(line);
   if (index > 0 && index < len) {
@@ -73,7 +70,7 @@ let isBetweenPairs = (line, index) => {
       (p: AutoClosingPair.t) =>
         p.opening == String.sub(line, index - 1, 1)
         && p.closing == String.sub(line, index, 1),
-      closingPairs^.pairs,
+      closingPairs.pairs,
     );
   } else {
     false;
@@ -86,12 +83,12 @@ let _exists = (key, hashtbl) =>
   | None => false
   };
 
-let canCloseBefore = (line, index) => {
+let canCloseBefore = (line, index, closingPairs) => {
   let index = Index.toZeroBased(index);
   let len = String.length(line);
   if (index > 0 && index < len) {
     let nextChar = String.sub(line, index, 1);
-    _exists(nextChar, closingPairs^.before);
+    _exists(nextChar, closingPairs.before);
   } else {
     true;
         // No character past cursor, always allow

--- a/src/Options.re
+++ b/src/Options.re
@@ -1,9 +1,7 @@
 type t = Native.buffer;
 
-let setAutoClosingPairs = AutoClosingPairs.setEnabled;
 let setTabSize = Native.vimOptionSetTabSize;
 let setInsertSpaces = Native.vimOptionSetInsertSpaces;
 
-let getAutoClosingPairs = AutoClosingPairs.getEnabled;
 let getTabSize = Native.vimOptionGetTabSize;
 let getInsertSpaces = Native.vimOptionGetInsertSpaces;

--- a/src/Vim.re
+++ b/src/Vim.re
@@ -219,18 +219,22 @@ let _getDefaultCursors = (cursors: list(Cursor.t)) =>
     cursors;
   };
 
-let input = (~cursors=[], v: string) => {
+let input = (~autoClosingPairs=AutoClosingPairs.empty, ~cursors=[], v: string) => {
   checkAndUpdateState(() => {
     // Special auto-closing pairs handling...
 
     let runCursor = cursor => {
       Cursor.set(cursor);
-      if (AutoClosingPairs.getEnabled() && Mode.getCurrent() == Types.Insert) {
+      if (Mode.getCurrent() == Types.Insert) {
         let location = Cursor.getLocation();
         let line = Buffer.getLine(Buffer.getCurrent(), location.line);
 
         let isBetweenPairs = () => {
-          AutoClosingPairs.isBetweenPairs(line, location.column);
+          AutoClosingPairs.isBetweenPairs(
+            line,
+            location.column,
+            autoClosingPairs,
+          );
         };
 
         let doesNextCharacterMatch = s => {
@@ -238,7 +242,11 @@ let input = (~cursors=[], v: string) => {
         };
 
         let canCloseBefore = () =>
-          AutoClosingPairs.canCloseBefore(line, location.column);
+          AutoClosingPairs.canCloseBefore(
+            line,
+            location.column,
+            autoClosingPairs,
+          );
 
         if (v == "<BS>" && isBetweenPairs()) {
           Native.vimInput("<DEL>");
@@ -248,11 +256,12 @@ let input = (~cursors=[], v: string) => {
           Native.vimInput("<CR>");
           Native.vimInput("<UP>");
           Native.vimInput("<TAB>");
-        } else if (AutoClosingPairs.isClosingPair(v)
+        } else if (AutoClosingPairs.isClosingPair(v, autoClosingPairs)
                    && doesNextCharacterMatch(v)) {
           Native.vimInput("<RIGHT>");
-        } else if (AutoClosingPairs.isOpeningPair(v) && canCloseBefore()) {
-          let pair = AutoClosingPairs.getByOpeningPair(v);
+        } else if (AutoClosingPairs.isOpeningPair(v, autoClosingPairs)
+                   && canCloseBefore()) {
+          let pair = AutoClosingPairs.getByOpeningPair(v, autoClosingPairs);
           Native.vimInput(v);
           Native.vimInput(pair.closing);
           Native.vimInput("<LEFT>");
@@ -268,7 +277,7 @@ let input = (~cursors=[], v: string) => {
     let mode = Mode.getCurrent();
     let cursors = _getDefaultCursors(cursors);
     if (mode == Types.Insert) {
-      // Run first command, verify we don't go back to insert mode
+      // Run first command, verify we don't go back to normal mode
       switch (cursors) {
       | [hd, ...tail] =>
         let newHead = runCursor(hd);

--- a/src/Vim.rei
+++ b/src/Vim.rei
@@ -15,7 +15,13 @@ The value [s] may be of the following form:
 
 The keystroke is processed synchronously.
 */
-let input: (~cursors: list(Cursor.t)=?, string) => list(Cursor.t);
+let input:
+  (
+    ~autoClosingPairs: AutoClosingPairs.t=?,
+    ~cursors: list(Cursor.t)=?,
+    string
+  ) =>
+  list(Cursor.t);
 
 /**
 [command(cmd)] executes [cmd] as an Ex command.

--- a/test/MultiCursorTest.re
+++ b/test/MultiCursorTest.re
@@ -38,13 +38,12 @@ describe("Multi-cursor", ({describe, _}) => {
     test("multi-cursor auto-closing paris", ({expect}) => {
       let buf = resetBuffer();
 
-      Options.setAutoClosingPairs(true);
-      AutoClosingPairs.create(
-        AutoClosingPairs.[
-          AutoClosingPair.create(~opening="{", ~closing="}", ()),
-        ],
-      )
-      |> AutoClosingPairs.setPairs;
+      let autoClosingPairs =
+        AutoClosingPairs.create(
+          AutoClosingPairs.[
+            AutoClosingPair.create(~opening="{", ~closing="}", ()),
+          ],
+        );
 
       let updates: ref(list(BufferUpdate.t)) = ref([]);
       let dispose = Buffer.onUpdate(upd => updates := [upd, ...updates^]);
@@ -54,6 +53,7 @@ describe("Multi-cursor", ({describe, _}) => {
 
       let cursors =
         Vim.input(
+          ~autoClosingPairs,
           ~cursors=[
             Cursor.create(~line=Index.zero, ~column=Index.zero),
             Cursor.create(~line=Index.(zero + 1), ~column=Index.zero),
@@ -76,7 +76,7 @@ describe("Multi-cursor", ({describe, _}) => {
         "{}This is the third line of a test file",
       );
 
-      let _ = Vim.input(~cursors, "a");
+      let _ = Vim.input(~autoClosingPairs, ~cursors, "a");
 
       let line1 = Buffer.getLine(buf, Index.zero);
       let line2 = Buffer.getLine(buf, Index.(zero + 1));


### PR DESCRIPTION
This moves the AutoClosingPairs from being a 'stateful' feature to something that we pass in the `input` method.

This simplifies the 'book-keeping' since we no longer need to manage the state here, and make it easier to support dynamic behavior - like not using certain auto closing pairs depending on the syntax environment.