### PR TITLE
API - AutoClosingPairs: Refine pass-through / auto-delete behavior

### DIFF
--- a/src/AutoClosingPairs.re
+++ b/src/AutoClosingPairs.re
@@ -16,14 +16,22 @@ type t = {
   before: Hashtbl.t(string, bool),
 };
 
-let empty: t = {passThrough: [], deletionPairs: [], pairs: [], before: Hashtbl.create(0)};
+let empty: t = {
+  passThrough: [],
+  deletionPairs: [],
+  pairs: [],
+  before: Hashtbl.create(0),
+};
 
-let create = (~allowBefore=[], ~passThrough=?, ~deletionPairs=?, p: list(AutoPair.t)) => {
-  let deletionPairs =
-     Option.value(deletionPairs, ~default=p);
+let create =
+    (~allowBefore=[], ~passThrough=?, ~deletionPairs=?, p: list(AutoPair.t)) => {
+  let deletionPairs = Option.value(deletionPairs, ~default=p);
 
   let passThrough =
-    Option.value(passThrough, ~default=List.map((pair: AutoPair.t) => pair.closing, p));
+    Option.value(
+      passThrough,
+      ~default=List.map((pair: AutoPair.t) => pair.closing, p),
+    );
 
   let hash = Hashtbl.create(16);
   List.iter(item => Hashtbl.add(hash, item, true), allowBefore);
@@ -43,7 +51,7 @@ let isClosingPair = (c, closingPairs: t) => {
 };
 
 let isPassThroughPair = (c, closingPairs: t) => {
-  List.exists((str) => str == c, closingPairs.passThrough);
+  List.exists(str => str == c, closingPairs.passThrough);
 };
 
 let getByOpeningPair = (c, closingPairs: t) => {
@@ -109,5 +117,5 @@ let doesNextCharacterMatch = (line, index, s) => {
 
 let isPassThrough = (character, line, index, autoClosingPairs) => {
   isPassThroughPair(character, autoClosingPairs)
-   && doesNextCharacterMatch(line, index, character);
+  && doesNextCharacterMatch(line, index, character);
 };

--- a/src/Vim.re
+++ b/src/Vim.re
@@ -253,8 +253,8 @@ let input = (~autoClosingPairs=AutoClosingPairs.empty, ~cursors=[], v: string) =
         let location = Cursor.getLocation();
         let line = Buffer.getLine(Buffer.getCurrent(), location.line);
 
-        let isBetweenPairs = () => {
-          AutoClosingPairs.isBetweenPairs(
+        let isBetweenClosingPairs = () => {
+          AutoClosingPairs.isBetweenClosingPairs(
             line,
             location.column,
             autoClosingPairs,
@@ -272,10 +272,15 @@ let input = (~autoClosingPairs=AutoClosingPairs.empty, ~cursors=[], v: string) =
             autoClosingPairs,
           );
 
-        if (v == "<BS>" && isBetweenPairs()) {
+        if (v == "<BS>"
+            && AutoClosingPairs.isBetweenDeletionPairs(
+                 line,
+                 location.column,
+                 autoClosingPairs,
+               )) {
           Native.vimInput("<DEL>");
           Native.vimInput("<BS>");
-        } else if (v == "<CR>" && isBetweenPairs()) {
+        } else if (v == "<CR>" && isBetweenClosingPairs()) {
           Native.vimInput("<CR>");
           Native.vimInput("<CR>");
           Native.vimInput("<UP>");

--- a/src/Vim.re
+++ b/src/Vim.re
@@ -281,7 +281,12 @@ let input = (~autoClosingPairs=AutoClosingPairs.empty, ~cursors=[], v: string) =
           Native.vimInput("<CR>");
           Native.vimInput("<UP>");
           Native.vimInput("<TAB>");
-        } else if (AutoClosingPairs.isPassThrough(v, line, location.column, autoClosingPairs)) {
+        } else if (AutoClosingPairs.isPassThrough(
+                     v,
+                     line,
+                     location.column,
+                     autoClosingPairs,
+                   )) {
           Native.vimInput("<RIGHT>");
         } else if (AutoClosingPairs.isOpeningPair(v, autoClosingPairs)
                    && canCloseBefore()) {

--- a/src/Vim.re
+++ b/src/Vim.re
@@ -261,10 +261,6 @@ let input = (~autoClosingPairs=AutoClosingPairs.empty, ~cursors=[], v: string) =
           );
         };
 
-        let doesNextCharacterMatch = s => {
-          AutoClosingPairs.doesNextCharacterMatch(line, location.column, s);
-        };
-
         let canCloseBefore = () =>
           AutoClosingPairs.canCloseBefore(
             line,
@@ -285,8 +281,7 @@ let input = (~autoClosingPairs=AutoClosingPairs.empty, ~cursors=[], v: string) =
           Native.vimInput("<CR>");
           Native.vimInput("<UP>");
           Native.vimInput("<TAB>");
-        } else if (AutoClosingPairs.isClosingPair(v, autoClosingPairs)
-                   && doesNextCharacterMatch(v)) {
+        } else if (AutoClosingPairs.isPassThrough(v, line, location.column, autoClosingPairs)) {
           Native.vimInput("<RIGHT>");
         } else if (AutoClosingPairs.isOpeningPair(v, autoClosingPairs)
                    && canCloseBefore()) {

--- a/src/Vim.rei
+++ b/src/Vim.rei
@@ -1,3 +1,23 @@
+open EditorCoreTypes;
+
+module AutoClosingPairs: {
+
+  module AutoClosingPair: {
+    type t = {
+      opening: string,
+      closing: string,
+    };
+  }
+
+  type t;
+
+  let empty: t;
+
+  let create: (~allowBefore: list(string)=?, list(AutoClosingPair.t)) => t;
+
+  let isBetweenPairs: (string, Index.t, t) => bool;
+};
+
 /**
 [init] must be called prior to [input] or [command], and must only be called once.
 
@@ -99,7 +119,6 @@ this could happen as a result of a yank or a delete command.
 */
 let onYank: Listeners.yankListener => Event.unsubscribe;
 
-module AutoClosingPairs = AutoClosingPairs;
 module AutoCommands = AutoCommands;
 module Buffer = Buffer;
 module BufferMetadata = BufferMetadata;

--- a/src/Vim.rei
+++ b/src/Vim.rei
@@ -8,8 +8,6 @@ module AutoClosingPairs: {
     };
   };
 
-  type passThroughCharacter = string;
-
   type t;
 
   let empty: t;
@@ -17,7 +15,7 @@ module AutoClosingPairs: {
   let create:
     (
       ~allowBefore: list(string)=?,
-      //~passThrough: list(passThroughCharacter)=?,
+      ~passThrough: list(string)=?,
       ~deletionPairs: list(AutoPair.t)=?,
       list(AutoPair.t)
     ) =>

--- a/src/Vim.rei
+++ b/src/Vim.rei
@@ -1,21 +1,31 @@
 open EditorCoreTypes;
 
 module AutoClosingPairs: {
-
-  module AutoClosingPair: {
+  module AutoPair: {
     type t = {
       opening: string,
       closing: string,
     };
-  }
+  };
+
+  type passThroughCharacter = string;
 
   type t;
 
   let empty: t;
 
-  let create: (~allowBefore: list(string)=?, list(AutoClosingPair.t)) => t;
+  let create:
+    (
+      ~allowBefore: list(string)=?,
+      //~passThrough: list(passThroughCharacter)=?,
+      ~deletionPairs: list(AutoPair.t)=?,
+      list(AutoPair.t)
+    ) =>
+    t;
 
-  let isBetweenPairs: (string, Index.t, t) => bool;
+  let isBetweenClosingPairs: (string, Index.t, t) => bool;
+
+  let isBetweenDeletionPairs: (string, Index.t, t) => bool;
 };
 
 /**

--- a/test/AutoClosingPairsTest.re
+++ b/test/AutoClosingPairsTest.re
@@ -6,6 +6,13 @@ let resetBuffer = () => Helpers.resetBuffer("test/testfile.txt");
 let input = (~autoClosingPairs=AutoClosingPairs.empty, s) =>
   ignore(Vim.input(~autoClosingPairs, s));
 
+open AutoClosingPairs;
+let quote = {|"|};
+let parenthesesPair = AutoClosingPair.{opening: "(", closing: ")"};
+let squareBracketPair = AutoClosingPair.{opening:"[", closing: "]"};
+let curlyBracketPair = AutoClosingPair.{opening:"{", closing: "}"};
+let quotePair = AutoClosingPair.{opening: quote, closing: quote};
+
 describe("AutoClosingPairs", ({test, _}) => {
   test("no auto-closing pairs", ({expect}) => {
     let b = resetBuffer();
@@ -24,8 +31,8 @@ describe("AutoClosingPairs", ({test, _}) => {
     let b = resetBuffer();
     let autoClosingPairs =
       AutoClosingPairs.create(
-        AutoClosingPairs.[
-          AutoClosingPair.create(~opening="[", ~closing="]", ()),
+        [
+          squareBracketPair
         ],
       );
 
@@ -43,8 +50,8 @@ describe("AutoClosingPairs", ({test, _}) => {
     let b = resetBuffer();
     let autoClosingPairs =
       AutoClosingPairs.create(
-        AutoClosingPairs.[
-          AutoClosingPair.create(~opening="[", ~closing="]", ()),
+        [
+          squareBracketPair
         ],
       );
 
@@ -70,8 +77,8 @@ describe("AutoClosingPairs", ({test, _}) => {
 
     let autoClosingPairs =
       AutoClosingPairs.create(
-        AutoClosingPairs.[
-          AutoClosingPair.create(~opening="[", ~closing="]", ()),
+        [
+          squareBracketPair
         ],
       );
 
@@ -88,8 +95,8 @@ describe("AutoClosingPairs", ({test, _}) => {
 
     let autoClosingPairs =
       AutoClosingPairs.create(
-        AutoClosingPairs.[
-          AutoClosingPair.create(~opening="[", ~closing="]", ()),
+        [
+          squareBracketPair
         ],
       );
 
@@ -107,8 +114,8 @@ describe("AutoClosingPairs", ({test, _}) => {
     let b = resetBuffer();
     let autoClosingPairs =
       AutoClosingPairs.create(
-        AutoClosingPairs.[
-          AutoClosingPair.create(~opening="(", ~closing=")", ()),
+        [
+          quotePair
         ],
       );
 
@@ -126,11 +133,10 @@ describe("AutoClosingPairs", ({test, _}) => {
   test(
     "pass-through not between pairs, with same begin/end pair", ({expect}) => {
     let b = resetBuffer();
-    let quote = {|"|};
     let autoClosingPairs =
       AutoClosingPairs.create(
-        AutoClosingPairs.[
-          AutoClosingPair.create(~opening=quote, ~closing=quote, ()),
+        [
+          quotePair
         ],
       );
 
@@ -149,8 +155,8 @@ describe("AutoClosingPairs", ({test, _}) => {
     let b = resetBuffer();
     let autoClosingPairs =
       AutoClosingPairs.create(
-        AutoClosingPairs.[
-          AutoClosingPair.create(~opening="[", ~closing="]", ()),
+        [
+          quotePair
         ],
       );
 
@@ -167,10 +173,10 @@ describe("AutoClosingPairs", ({test, _}) => {
       AutoClosingPairs.create(
         ~allowBefore=["]", "}", ")", "\""],
         AutoClosingPairs.[
-          AutoClosingPair.create(~opening="[", ~closing="]", ()),
-          AutoClosingPair.create(~opening="{", ~closing="}", ()),
-          AutoClosingPair.create(~opening="(", ~closing=")", ()),
-          AutoClosingPair.create(~opening="\"", ~closing="\"", ()),
+          squareBracketPair,
+          curlyBracketPair,
+          parenthesesPair,
+          quotePair,
         ],
       );
 

--- a/test/AutoClosingPairsTest.re
+++ b/test/AutoClosingPairsTest.re
@@ -107,6 +107,24 @@ describe("AutoClosingPairs", ({test, _}) => {
     expect.int((location.column :> int)).toBe(2);
   });
 
+  test("pass-through between pairs, overridden", ({expect}) => {
+    let b = resetBuffer();
+
+    let autoClosingPairs = AutoClosingPairs.create([squareBracketPair]);
+
+    input(~autoClosingPairs, "O");
+    input(~autoClosingPairs, "[");
+
+    let autoClosingPairs =
+      AutoClosingPairs.create(~passThrough=["]"], [squareBracketPair]);
+    input(~autoClosingPairs, "]");
+
+    let line = Buffer.getLine(b, Index.zero);
+    let location = Cursor.getLocation();
+    expect.string(line).toEqual("[]");
+    expect.int((location.column :> int)).toBe(2);
+  });
+
   test("pass-through not between pairs", ({expect}) => {
     let b = resetBuffer();
     let autoClosingPairs = AutoClosingPairs.create([quotePair]);

--- a/test/AutoClosingPairsTest.re
+++ b/test/AutoClosingPairsTest.re
@@ -8,10 +8,10 @@ let input = (~autoClosingPairs=AutoClosingPairs.empty, s) =>
 
 open AutoClosingPairs;
 let quote = {|"|};
-let parenthesesPair = AutoClosingPair.{opening: "(", closing: ")"};
-let squareBracketPair = AutoClosingPair.{opening:"[", closing: "]"};
-let curlyBracketPair = AutoClosingPair.{opening:"{", closing: "}"};
-let quotePair = AutoClosingPair.{opening: quote, closing: quote};
+let parenthesesPair = AutoPair.{opening: "(", closing: ")"};
+let squareBracketPair = AutoPair.{opening: "[", closing: "]"};
+let curlyBracketPair = AutoPair.{opening: "{", closing: "}"};
+let quotePair = AutoPair.{opening: quote, closing: quote};
 
 describe("AutoClosingPairs", ({test, _}) => {
   test("no auto-closing pairs", ({expect}) => {
@@ -29,12 +29,7 @@ describe("AutoClosingPairs", ({test, _}) => {
 
   test("single acp", ({expect}) => {
     let b = resetBuffer();
-    let autoClosingPairs =
-      AutoClosingPairs.create(
-        [
-          squareBracketPair
-        ],
-      );
+    let autoClosingPairs = AutoClosingPairs.create([squareBracketPair]);
 
     input(~autoClosingPairs, "O");
     input(~autoClosingPairs, "[");
@@ -46,14 +41,9 @@ describe("AutoClosingPairs", ({test, _}) => {
     expect.string(line).toEqual("[(\"{]");
   });
 
-  test("isBetweenPairs", ({expect}) => {
+  test("isBetweenClosingPairs", ({expect}) => {
     let b = resetBuffer();
-    let autoClosingPairs =
-      AutoClosingPairs.create(
-        [
-          squareBracketPair
-        ],
-      );
+    let autoClosingPairs = AutoClosingPairs.create([squareBracketPair]);
 
     input(~autoClosingPairs, "O");
     input(~autoClosingPairs, "[");
@@ -61,7 +51,7 @@ describe("AutoClosingPairs", ({test, _}) => {
     let line = Buffer.getLine(b, Index.zero);
     let location = Cursor.getLocation();
     expect.bool(
-      AutoClosingPairs.isBetweenPairs(
+      AutoClosingPairs.isBetweenClosingPairs(
         line,
         location.column,
         autoClosingPairs,
@@ -75,11 +65,23 @@ describe("AutoClosingPairs", ({test, _}) => {
   test("backspace between pairs", ({expect}) => {
     let b = resetBuffer();
 
+    let autoClosingPairs = AutoClosingPairs.create([squareBracketPair]);
+
+    input(~autoClosingPairs, "O");
+    input(~autoClosingPairs, "[");
+    input(~autoClosingPairs, "<BS>");
+
+    let line = Buffer.getLine(b, Index.zero);
+    expect.string(line).toEqual("");
+  });
+
+  test("backspace between pairs, override deletion pairs", ({expect}) => {
+    let b = resetBuffer();
+
     let autoClosingPairs =
       AutoClosingPairs.create(
-        [
-          squareBracketPair
-        ],
+        ~deletionPairs=[squareBracketPair],
+        [quotePair],
       );
 
     input(~autoClosingPairs, "O");
@@ -93,12 +95,7 @@ describe("AutoClosingPairs", ({test, _}) => {
   test("pass-through between pairs", ({expect}) => {
     let b = resetBuffer();
 
-    let autoClosingPairs =
-      AutoClosingPairs.create(
-        [
-          squareBracketPair
-        ],
-      );
+    let autoClosingPairs = AutoClosingPairs.create([squareBracketPair]);
 
     input(~autoClosingPairs, "O");
     input(~autoClosingPairs, "[");
@@ -112,12 +109,7 @@ describe("AutoClosingPairs", ({test, _}) => {
 
   test("pass-through not between pairs", ({expect}) => {
     let b = resetBuffer();
-    let autoClosingPairs =
-      AutoClosingPairs.create(
-        [
-          quotePair
-        ],
-      );
+    let autoClosingPairs = AutoClosingPairs.create([quotePair]);
 
     input(~autoClosingPairs, "O");
     input(~autoClosingPairs, "(");
@@ -133,12 +125,7 @@ describe("AutoClosingPairs", ({test, _}) => {
   test(
     "pass-through not between pairs, with same begin/end pair", ({expect}) => {
     let b = resetBuffer();
-    let autoClosingPairs =
-      AutoClosingPairs.create(
-        [
-          quotePair
-        ],
-      );
+    let autoClosingPairs = AutoClosingPairs.create([quotePair]);
 
     input(~autoClosingPairs, "O");
     input(~autoClosingPairs, quote);
@@ -153,12 +140,7 @@ describe("AutoClosingPairs", ({test, _}) => {
 
   test("can insert closing pair", ({expect}) => {
     let b = resetBuffer();
-    let autoClosingPairs =
-      AutoClosingPairs.create(
-        [
-          quotePair
-        ],
-      );
+    let autoClosingPairs = AutoClosingPairs.create([quotePair]);
 
     input(~autoClosingPairs, "O");
     input(~autoClosingPairs, "]");

--- a/test/MultiCursorTest.re
+++ b/test/MultiCursorTest.re
@@ -41,7 +41,7 @@ describe("Multi-cursor", ({describe, _}) => {
       let autoClosingPairs =
         AutoClosingPairs.create(
           AutoClosingPairs.[
-            AutoClosingPair.create(~opening="{", ~closing="}", ()),
+            AutoClosingPair.{opening:"{", closing:"}"}
           ],
         );
 

--- a/test/MultiCursorTest.re
+++ b/test/MultiCursorTest.re
@@ -40,9 +40,7 @@ describe("Multi-cursor", ({describe, _}) => {
 
       let autoClosingPairs =
         AutoClosingPairs.create(
-          AutoClosingPairs.[
-            AutoClosingPair.{opening:"{", closing:"}"}
-          ],
+          AutoClosingPairs.[AutoPair.{opening: "{", closing: "}"}],
         );
 
       let updates: ref(list(BufferUpdate.t)) = ref([]);


### PR DESCRIPTION
For auto-closing pairs, there are cases where we might want to specify the 'pass-through' and 'auto-delete' behavior independently, to give the consumer more control.

A case like this happens in Onivim 2, where, due to syntax, some auto-closing pairs may be disabled (for example, auto-closing inside a string). As `reason-libvim` doesn't know about syntax scopes - we filter out the set of auto-closing pairs prior to sending them to `reason-libvim`. 

However, this also breaks the pass-through and deletion behavior that we'd expect would still work. This change allows us to filter the auto-closing pairs based on syntax scope, but still use the full set of pass-through and deletion pairs.